### PR TITLE
Removed min/max macros to prevent header include problems with LLVM.

### DIFF
--- a/src/LbfgsbSolver.cpp
+++ b/src/LbfgsbSolver.cpp
@@ -169,7 +169,7 @@ void LbfgsbSolver::GetGeneralizedCauchyPoint(Vector &x, Vector &g, Vector &x_cau
 
   }
 
-  dt_min = max(dt_min, 0);
+  dt_min = max(dt_min, 0.0);
   t_old += dt_min;
 
   Debug(SortedIndices[0] << " " << SortedIndices[1]);

--- a/src/LbfgsbSolver.h
+++ b/src/LbfgsbSolver.h
@@ -22,8 +22,8 @@
 
 #ifndef LBFGSBSOLVER_H_
 #define LBFGSBSOLVER_H_
-#include "ISolver.h"
 #include <list>
+#include "ISolver.h"
 namespace pwie
 {
 

--- a/src/Meta.h
+++ b/src/Meta.h
@@ -28,6 +28,9 @@
 #include <Eigen/Dense>
 #include <Eigen/Core>
 #include <stdexcept>
+#include <list>
+#include <vector>
+#include <algorithm>
 
 namespace pwie
 {
@@ -84,8 +87,9 @@ bool AssertEqual(T a, T b)
 }
 }
 
-#define min(a,b) (((a)<(b))?(a):(b))
-#define max(a,b) (((a)>(b))?(a):(b))
+using std::min;
+using std::max;
+
 #define EMPTY_HESSIAN (std::function<void(const Eigen::VectorXd & x, Eigen::MatrixXd & hessian)>())
 
 #define INF HUGE_VAL // std::numeric_limits<double>::infinity()


### PR DESCRIPTION
Hello,
I am trying your LBFGS solver in my application. I had similar problems to this bug in Eigen: https://bitbucket.org/eigen/eigen/pull-request/81/fix-for-warning-on-macro-definitions-of/diff

The best way I found of fixing it was to remove the macros and use the std::min and std::max functions.

Thanks,
Toby