### PR TITLE
add #include "../problem.h" into isolver.h

### DIFF
--- a/include/cppoptlib/solver/isolver.h
+++ b/include/cppoptlib/solver/isolver.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include "isolver.h"
 #include "../meta.h"
+#include "../problem.h"
 
 namespace cppoptlib {
 


### PR DESCRIPTION
Hello
I found that isolver.h used template class Problem but not includes it. Of course this issue is not critical . But it forces user to include problem.h with solvers.