### PR TITLE
To allow compilation of solvers with <float> as template parameter ad…

### DIFF
--- a/include/cppoptlib/linesearch/morethuente.h
+++ b/include/cppoptlib/linesearch/morethuente.h
@@ -3,6 +3,7 @@
 #define MORETHUENTE_H_
 
 #include "../meta.h"
+#include <cmath>
 
 namespace cppoptlib {
 
@@ -224,7 +225,7 @@ class MoreThuente {
       bound = 1;
       Dtype theta = 3 * (fx - fp) / (stp - stx) + dx + dp;
       Dtype s = std::max(theta, std::max( dx, dp));
-      Dtype gamma = s * sqrt(std::max(0., (theta / s) * (theta / s) - (dx / s) * (dp / s)));
+      Dtype gamma = s * sqrt(std::max(static_cast<Dtype>(0.), (theta / s) * (theta / s) - (dx / s) * (dp / s)));
       if (stp > stx)
         gamma = -gamma;
       Dtype p = (gamma - dp) + theta;
@@ -296,9 +297,9 @@ class MoreThuente {
 
     if (brackt & bound) {
       if (sty > stx) {
-        stp = std::min(stx + 0.66 * (sty - stx), stp);
+        stp = std::min(stx + static_cast<Dtype>(0.66) * (sty - stx), stp);
       } else {
-        stp = std::max(stx + 0.66 * (sty - stx), stp);
+        stp = std::max(stx + static_cast<Dtype>(0.66) * (sty - stx), stp);
       }
     }
 

--- a/include/cppoptlib/problem.h
+++ b/include/cppoptlib/problem.h
@@ -105,7 +105,7 @@ class Problem {
     bool correct = true;
 
     for (int d = 0; d < D; ++d) {
-      T scale = std::max(std::max(fabs(actual_grad[d]), fabs(expected_grad[d])), (T)1.);
+      T scale = std::max((std::max(fabs(actual_grad[d]), fabs(expected_grad[d]))), 1.);
       EXPECT_NEAR(actual_grad[d], expected_grad[d], 1e-2 * scale);
       if(fabs(actual_grad[d]-expected_grad[d])>1e-2 * scale)
         correct = false;
@@ -126,7 +126,7 @@ class Problem {
     finiteHessian(x, expected_hessian, accuracy);
     for (int d = 0; d < D; ++d) {
       for (int e = 0; e < D; ++e) {
-        T scale = std::max(std::max(fabs(actual_hessian(d, e)), fabs(expected_hessian(d, e))), (T)1.);
+        T scale = std::max(static_cast<T>(std::max(fabs(actual_hessian(d, e)), fabs(expected_hessian(d, e)))), (T)1.);
         EXPECT_NEAR(actual_hessian(d, e), expected_hessian(d, e), 1e-1 * scale);
         if(fabs(actual_hessian(d, e)- expected_hessian(d, e))>1e-1 * scale)
         correct = false;
@@ -138,7 +138,7 @@ class Problem {
 
   virtual void finiteGradient(const  Vector<T> &x, Vector<T> &grad, int accuracy = 0) final {
     // accuracy can be 0, 1, 2, 3
-    const T eps = 2.2204e-8;
+    const T eps = 2.2204e-6;
     const size_t D = x.rows();
     const std::vector< std::vector <T>> coeff =
     { {1, -1}, {1, -8, 8, -1}, {-1, 9, -45, 45, -9, 1}, {3, -32, 168, -672, 672, -168, 32, -3} };

--- a/include/cppoptlib/solver/cmaessolver.h
+++ b/include/cppoptlib/solver/cmaessolver.h
@@ -47,12 +47,12 @@ class CMAesSolver : public ISolver<T, 1> {
   Vector<T> sampleMvn(Vector<T> &mean, Matrix<T> &covar) {
 
     Matrix<T> normTransform;
-    Eigen::LLT<Eigen::MatrixXd> cholSolver(covar);
+    Eigen::LLT<Matrix<T>> cholSolver(covar);
 
     if (cholSolver.info() == Eigen::Success) {
       normTransform = cholSolver.matrixL();
     } else {
-      Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigenSolver(covar);
+      Eigen::SelfAdjointEigenSolver<Matrix<T>> eigenSolver(covar);
       normTransform = eigenSolver.eigenvectors() * eigenSolver.eigenvalues().cwiseSqrt().asDiagonal();
     }
 
@@ -62,7 +62,7 @@ class CMAesSolver : public ISolver<T, 1> {
       stdNormDistr[i] = d(gen);
     }
 
-    Eigen::MatrixXd samples = normTransform * stdNormDistr + mean;
+    Matrix<T> samples = normTransform * stdNormDistr + mean;
 
     return samples;
   }
@@ -104,7 +104,7 @@ class CMAesSolver : public ISolver<T, 1> {
 
     const T sigma0   = 0.3 * (VarMax - VarMin);
     const T cs       = (mu_eff + 2.) / (DIM + mu_eff + 5.);
-    const T ds       = 1. + cs + 2.*std::max(sqrt((mu_eff - 1) / (DIM + 1)) - 1, (T)0.);
+    const T ds       = 1. + cs + 2.*std::max(static_cast<T>(sqrt((mu_eff - 1) / (DIM + 1)) - 1), (T)0.);
     const T ENN      = sqrt(DIM) * (1 - 1. / (4.*DIM) + 1. / (21.*DIM * DIM));
 
     const T cc       = (4. + mu_eff / DIM) / (4. + DIM + 2.*mu_eff / DIM);

--- a/include/cppoptlib/solver/cmaessolver.h
+++ b/include/cppoptlib/solver/cmaessolver.h
@@ -47,12 +47,12 @@ class CMAesSolver : public ISolver<T, 1> {
   Vector<T> sampleMvn(Vector<T> &mean, Matrix<T> &covar) {
 
     Matrix<T> normTransform;
-    Eigen::LLT<Matrix<T>> cholSolver(covar);
+    Eigen::LLT<Eigen::MatrixXd> cholSolver(covar);
 
     if (cholSolver.info() == Eigen::Success) {
       normTransform = cholSolver.matrixL();
     } else {
-      Eigen::SelfAdjointEigenSolver<Matrix<T>> eigenSolver(covar);
+      Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigenSolver(covar);
       normTransform = eigenSolver.eigenvectors() * eigenSolver.eigenvalues().cwiseSqrt().asDiagonal();
     }
 
@@ -62,7 +62,7 @@ class CMAesSolver : public ISolver<T, 1> {
       stdNormDistr[i] = d(gen);
     }
 
-    Matrix<T> samples = normTransform * stdNormDistr + mean;
+    Eigen::MatrixXd samples = normTransform * stdNormDistr + mean;
 
     return samples;
   }
@@ -104,7 +104,7 @@ class CMAesSolver : public ISolver<T, 1> {
 
     const T sigma0   = 0.3 * (VarMax - VarMin);
     const T cs       = (mu_eff + 2.) / (DIM + mu_eff + 5.);
-    const T ds       = 1. + cs + 2.*std::max(static_cast<T>(sqrt((mu_eff - 1) / (DIM + 1)) - 1), (T)0.);
+    const T ds       = 1. + cs + 2.*std::max(sqrt((mu_eff - 1) / (DIM + 1)) - 1, (T)0.);
     const T ENN      = sqrt(DIM) * (1 - 1. / (4.*DIM) + 1. / (21.*DIM * DIM));
 
     const T cc       = (4. + mu_eff / DIM) / (4. + DIM + 2.*mu_eff / DIM);

--- a/include/cppoptlib/solver/lbfgssolver.h
+++ b/include/cppoptlib/solver/lbfgssolver.h
@@ -33,7 +33,7 @@ class LbfgsSolver : public ISolver<T, 1> {
 
         do {
 
-            const double relativeEpsilon = 0.0001 * std::max(1.0, x0.norm());
+            const T relativeEpsilon = static_cast<T>(0.0001) * std::max(static_cast<T>(1.0), x0.norm());
 
             if (grad.norm() < relativeEpsilon)
                 break;

--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -67,8 +67,8 @@ class NelderMeadSolver : public ISolver<T, 0> {
         if (tmp2 > max2)
           max2 = tmp2;
       }
-      const T tt1 = std::max(1.e-04, 10 * std::nextafter<T>(f[index[0]], std::numeric_limits<T>::epsilon()) - f[index[0]]);
-      const T tt2 = std::max(1.e-04, 10 * (std::nextafter<T>(x0.col(index[0]).maxCoeff(), std::numeric_limits<T>::epsilon())
+      const T tt1 = std::max(static_cast<T>(1.e-04), 10 * std::nextafter<T>(f[index[0]], std::numeric_limits<T>::epsilon()) - f[index[0]]);
+      const T tt2 = std::max(static_cast<T>(1.e-04), 10 * (std::nextafter<T>(x0.col(index[0]).maxCoeff(), std::numeric_limits<T>::epsilon())
                     - x0.col(index[0]).maxCoeff()));
 
       // max(||x - shift(x) ||_inf ) <= tol,

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-SET( EXAMPLE_FILES linearregression logisticregression rosenbrock simple nonnegls)
+SET( EXAMPLE_FILES linearregression logisticregression rosenbrock rosenbrock_float simple nonnegls)
 
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/examples )
 foreach( currentfile ${EXAMPLE_FILES} )

--- a/src/examples/linearregression.cpp
+++ b/src/examples/linearregression.cpp
@@ -42,7 +42,7 @@ int main(int argc, char const *argv[]) {
 
     cppoptlib::Vector<T> beta = cppoptlib::Vector<T>::Random(4);
     std::cout << "start in   " << beta.transpose() << std::endl;
-    cppoptlib::BfgsSolver<double> solver;
+    cppoptlib::BfgsSolver<T> solver;
     solver.minimize(f, beta);
 
     std::cout << "result     " << beta.transpose() << std::endl;

--- a/src/examples/rosenbrock_float.cpp
+++ b/src/examples/rosenbrock_float.cpp
@@ -3,6 +3,10 @@
 #include "../../include/cppoptlib/problem.h"
 #include "../../include/cppoptlib/solver/bfgssolver.h"
 #include "../../include/cppoptlib/solver/conjugatedgradientdescentsolver.h"
+#include "../../include/cppoptlib/solver/newtondescentsolver.h"
+#include "../../include/cppoptlib/solver/neldermeadsolver.h"
+#include "../../include/cppoptlib/solver/lbfgssolver.h"
+#include "../../include/cppoptlib/solver/cmaessolver.h"
 
 // to use this library just use the namespace "cppoptlib"
 namespace cppoptlib {
@@ -49,11 +53,15 @@ int main(int argc, char const *argv[]) {
 
     // first check the given derivative 
     // there is output, if they are NOT similar to finite differences
-    bool probably_correct = f.checkGradient(x, 1);
+    bool probably_correct = f.checkGradient(x);
 
     // choose a solver
-    cppoptlib::BfgsSolver<float> solver;
+    //cppoptlib::BfgsSolver<T> solver;
     //cppoptlib::ConjugatedGradientDescentSolver<T> solver;
+    //cppoptlib::NewtonDescentSolver<T> solver;
+    //cppoptlib::NelderMeadSolver<T> solver;
+    cppoptlib::LbfgsSolver<T> solver;
+    //cppoptlib::CMAesSolver<T> solver;
     // and minimize the function
     solver.minimize(f, x);
     // print argmin

--- a/src/examples/rosenbrock_float.cpp
+++ b/src/examples/rosenbrock_float.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include "../../include/cppoptlib/meta.h"
+#include "../../include/cppoptlib/problem.h"
+#include "../../include/cppoptlib/solver/bfgssolver.h"
+#include "../../include/cppoptlib/solver/conjugatedgradientdescentsolver.h"
+
+// to use this library just use the namespace "cppoptlib"
+namespace cppoptlib {
+
+// we define a new problem for optimizing the rosenbrock function
+// we use a templated-class rather than "auto"-lambda function for a clean architecture
+template<typename T>
+class Rosenbrock : public Problem<T> {
+  public:
+    // this is just the objective (NOT optional)
+    T value(const Vector<T> &x) {
+        const T t1 = (1 - x[0]);
+        const T t2 = (x[1] - x[0] * x[0]);
+        return   t1 * t1 + 100 * t2 * t2;
+    }
+
+    // if you calculated the derivative by hand
+    // you can implement it here (OPTIONAL)
+    // otherwise it will fall back to (bad) numerical finite differences
+    void gradient(const Vector<T> &x, Vector<T> &grad) {
+        grad[0]  = -2 * (1 - x[0]) + 200 * (x[1] - x[0] * x[0]) * (-2 * x[0]);
+        grad[1]  =                   200 * (x[1] - x[0] * x[0]);
+    }
+
+    // same for hessian (OPTIONAL)
+    // if you want ot use 2nd-order solvers, I encourage you to specify the hessian
+    // finite differences usually (this implementation) behave bad
+    void hessian(const Vector<T> &x, Matrix<T> & hessian) {
+        hessian(0, 0) = 1200 * x[0] * x[0] - 400 * x[1] + 1;
+        hessian(0, 1) = -400 * x[0];
+        hessian(1, 0) = -400 * x[0];
+        hessian(1, 1) = 200;
+    }
+
+};
+
+}
+int main(int argc, char const *argv[]) {
+    typedef float T;
+    // initialize the Rosenbrock-problem
+    cppoptlib::Rosenbrock<T> f;
+    // choose a starting point
+    cppoptlib::Vector<T> x(2); x << -1, 2;
+
+    // first check the given derivative 
+    // there is output, if they are NOT similar to finite differences
+    bool probably_correct = f.checkGradient(x, 1);
+
+    // choose a solver
+    cppoptlib::BfgsSolver<float> solver;
+    //cppoptlib::ConjugatedGradientDescentSolver<T> solver;
+    // and minimize the function
+    solver.minimize(f, x);
+    // print argmin
+    std::cout << "argmin      " << x.transpose() << std::endl;
+    std::cout << "f in argmin " << f(x) << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
"…ded static_casts to linesearch/morethuente.h and problem.h

Modified example of rosenbrock minimising by Bfgs and CG with <float>
added.
Increase constant eps in finiteGradient because finiteGradient on
rosenbrock with <float> returns invalid value. Maybe it is not a good
idea"

Solution of https://github.com/PatWie/CppNumericalSolvers/issues/15 . Some  decisions maybe discussable.