### PR TITLE
Fix nextafter

### DIFF
--- a/include/cppoptlib/problem.h
+++ b/include/cppoptlib/problem.h
@@ -1,6 +1,8 @@
 #ifndef PROBLEM_H
 #define PROBLEM_H
 
+#include <vector>
+
 #include <Eigen/Dense>
 
 #if defined(MATLAB) || defined(NDEBUG)

--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -67,8 +67,8 @@ class NelderMeadSolver : public ISolver<T, 0> {
         if (tmp2 > max2)
           max2 = tmp2;
       }
-      const T tt1 = std::max(static_cast<T>(1.e-04), 10 * std::nextafter<T>(f[index[0]], std::numeric_limits<T>::epsilon()) - f[index[0]]);
-      const T tt2 = std::max(static_cast<T>(1.e-04), 10 * (std::nextafter<T>(x0.col(index[0]).maxCoeff(), std::numeric_limits<T>::epsilon())
+      const T tt1 = std::max(static_cast<T>(1.e-04), 10 * std::nextafter(f[index[0]], std::numeric_limits<T>::epsilon()) - f[index[0]]);
+      const T tt2 = std::max(static_cast<T>(1.e-04), 10 * (std::nextafter(x0.col(index[0]).maxCoeff(), std::numeric_limits<T>::epsilon())
                     - x0.col(index[0]).maxCoeff()));
 
       // max(||x - shift(x) ||_inf ) <= tol,


### PR DESCRIPTION
The call to std::nextafter<T> in Nelder Mead doesn't compile with my version of Clang. It causes definition 4  from http://en.cppreference.com/w/cpp/numeric/math/nextafter to be chosen at compile time, which is incorrect because the types of both arguments are the same, and a static_assert then fails. Removing the <T> allows the compiler to pick the double (double, double) version.