### PR TITLE
Stop criteria

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,69 @@
+sudo: required
+dist: precise
 language: cpp
-sudo: false
-compiler:
-  - clang++
-  - g++
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env: COMPILER=g++-4.9
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env: COMPILER=g++-5
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env: COMPILER=clang++-3.6
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env: COMPILER=clang++-3.7
+
 before_install:
+  - sudo apt-get update -qq
   - chmod u+x get_dependencies.sh
   - ./get_dependencies.sh
+  - git submodule update --init --recursive
+
+install:
+  ############################################################################
+  # Install a recent CMake
+  ############################################################################
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_DIR="install_cmake"
+      CMAKE_URL="http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz"
+      mkdir $CMAKE_DIR && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C $CMAKE_DIR
+      export PATH=${TRAVIS_BUILD_DIR}/${CMAKE_DIR}/bin:${PATH}
+    else
+      brew install cmake
+    fi
 
 script:
   - cp CppNumericalSolvers.config.example CppNumericalSolvers.config
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
   - make all
   - make lint
   - ./bin/verify

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 project(CppNumericalSolvers)
 
 include(CppNumericalSolvers.config)
@@ -8,16 +8,8 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set( CMAKE_TEST_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 
 # check existence of c++11 compiler
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 # set path to cmake modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 set(LINKER_LIBS "")

--- a/CppNumericalSolvers.config.example
+++ b/CppNumericalSolvers.config.example
@@ -1,4 +1,3 @@
 SET( EIGEN3_INCLUDE_DIR "eigen" )
-SET(CMAKE_CXX_COMPILER  "clang++")
-SET( GTEST_ROOT "gtest")
+SET( GTEST_ROOT "${PROJECT_SOURCE_DIR}/gtest")
 SET(Matlab_DIR  "/path/to/matlab")

--- a/include/cppoptlib/meta.h
+++ b/include/cppoptlib/meta.h
@@ -13,47 +13,97 @@ using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 template <typename T>
 using Matrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
-typedef struct Options {
-    double gradTol;
-    double rate;
-    size_t maxIter;
-    size_t m;
-
-    Options() {
-        rate = 0.00005;
-        maxIter = 100000;
-        gradTol = 1e-4;
-        m = 10;
-
-    }
-} Options;
+enum class DebugLevel { None = 0, Low, High };
+enum class Status {
+    NotStarted = -1,
+    Continue = 0,
+    IterationLimit,
+    XDeltaTolerance,
+    FDeltaTolerance,
+    GradNormTolerance,
+    Condition
+};
 
 template<typename T>
-bool checkConvergence(T val_new, T val_old, Vector<T> grad, Vector<T> x_new, Vector<T> x_old) {
+class Criteria {
+public:
+    size_t iterations; //!< Maximum number of iterations
+    T xDelta;          //!< Minimum change in parameter vector
+    T fDelta;          //!< Minimum change in cost function
+    T gradNorm;        //!< Minimum norm of gradient vector
+    T condition;       //!< Maximum condition number of Hessian
 
-    T ftol = 1e-10;
-    T gtol = 1e-8;
-    T xtol = 1e-32;
-
-    // value crit.
-    if((x_new-x_old).cwiseAbs().maxCoeff() < xtol)
-        return true;
-
-    // // absol. crit
-    if(abs(val_new - val_old) / (abs(val_new) + ftol) < ftol) {
-        std::cout << abs(val_new - val_old) / (abs(val_new) + ftol) << std::endl;
-        std::cout << val_new << std::endl;
-        std::cout << val_old << std::endl;
-        std::cout << abs(val_new - val_old) / (abs(val_new) + ftol) << std::endl;
-        return true;
+    Criteria() {
+        reset();
     }
 
-    // gradient crit
-    T g = grad.template lpNorm<Eigen::Infinity>();
-    if (g < gtol)
-        return true;
-    return false;
+    static Criteria defaults() {
+        Criteria d;
+        d.iterations = 10000;
+        d.xDelta = 0;
+        d.fDelta = 0;
+        d.gradNorm = 1e-4;
+        d.condition = 0;
+        return d;
+    }
+
+    void reset() {
+        iterations = 0;
+        xDelta = 0;
+        fDelta = 0;
+        gradNorm = 0;
+        condition = 0;
+    }
+
+    void print(std::ostream &os) {
+        os << "Iterations: " << iterations << std::endl;
+        os << "xDelta:     " << xDelta << std::endl;
+        os << "fDelta:     " << fDelta << std::endl;
+        os << "GradNorm:   " << gradNorm << std::endl;
+        os << "Condition:  " << condition << std::endl;
+    }
+};
+
+template<typename T>
+Status checkConvergence(const Criteria<T> &stop, const Criteria<T> &current) {
+
+    if ((stop.iterations > 0) && (current.iterations > stop.iterations)) {
+        return Status::IterationLimit;
+    }
+    if ((stop.xDelta > 0) && (current.xDelta < stop.xDelta)) {
+        return Status::XDeltaTolerance;
+    }
+    if ((stop.fDelta > 0) && (current.fDelta < stop.fDelta)) {
+        return Status::FDeltaTolerance;
+    }
+    if ((stop.gradNorm > 0) && (current.gradNorm < stop.gradNorm)) {
+        return Status::GradNormTolerance;
+    }
+    if ((stop.condition > 0) && (current.condition > stop.condition)) {
+        return Status::Condition;
+    }
+    return Status::Continue;
 }
 
 }
+
+std::ostream &operator<<(std::ostream &os, cppoptlib::Status &s) {
+    switch (s) {
+        case cppoptlib::Status::NotStarted: os << "Solver not started."; break;
+        case cppoptlib::Status::Continue:   os << "Convergence criteria not reached."; break;
+        case cppoptlib::Status::IterationLimit: os << "Iteration limit reached."; break;
+        case cppoptlib::Status::XDeltaTolerance: os << "Change in parameter vector too small."; break;
+        case cppoptlib::Status::FDeltaTolerance: os << "Change in cost function value too small."; break;
+        case cppoptlib::Status::GradNormTolerance: os << "Gradient vector norm too small."; break;
+        case cppoptlib::Status::Condition: os << "Condition of Hessian/Covariance matrix too large."; break;
+    }
+    return os;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &os, cppoptlib::Criteria<T> &c) {
+    c.print(os);
+    return os;
+}
+
 #endif /* META_H */

--- a/include/cppoptlib/solver/bfgssolver.h
+++ b/include/cppoptlib/solver/bfgssolver.h
@@ -13,14 +13,11 @@ template<typename T>
 class BfgsSolver : public ISolver<T, 1> {
   public:
     void minimize(Problem<T> &objFunc, Vector<T> & x0) {
-
         const size_t DIM = x0.rows();
-        size_t iter = 0;
         Matrix<T> H = Matrix<T>::Identity(DIM, DIM);
         Vector<T> grad(DIM);
-        T gradNorm = 0;
         Vector<T> x_old = x0;
-
+        this->m_current.reset();
         do {
             objFunc.gradient(x0, grad);
             Vector<T> searchDir = -1 * H * grad;
@@ -45,15 +42,15 @@ class BfgsSolver : public ISolver<T, 1> {
             const double rho = 1.0 / y.dot(s);
             H = H - rho * (s * (y.transpose() * H) + (H * y) * s.transpose()) + rho * rho * (y.dot(H * y) + 1.0 / rho)
                 * (s * s.transpose());
-            gradNorm = grad.template lpNorm<Eigen::Infinity>();
             // std::cout << "iter: "<<iter<< " f = " <<  objFunc.value(x0) << " ||g||_inf "<<gradNorm   << std::endl;
 
             if( (x_old-x0).template lpNorm<Eigen::Infinity>() < 1e-7  )
                 break;
             x_old = x0;
-            iter++;
-
-        } while ((gradNorm > this->settings_.gradTol) && (iter < this->settings_.maxIter));
+            ++this->m_current.iterations;
+            this->m_current.gradNorm = grad.template lpNorm<Eigen::Infinity>();
+            this->m_status = checkConvergence(this->m_stop, this->m_current);
+        } while (this->m_status == Status::Continue);
 
     }
 

--- a/include/cppoptlib/solver/cmaessolver.h
+++ b/include/cppoptlib/solver/cmaessolver.h
@@ -142,7 +142,7 @@ class CMAesSolver : public ISolver<T, 1> {
     Vector<T> zeroVectorTemplate = Vector<T>::Zero(DIM);
 
     // CMA-ES Main Loop
-    for (size_t curIter = 0; curIter < this->settings_.maxIter; ++curIter) {
+    for (size_t curIter = 0; curIter < this->m_stop.iterations; ++curIter) {
       std::vector<individual> pop;
 
       for (int i = 0; i < populationSize; ++i) {
@@ -167,7 +167,7 @@ class CMAesSolver : public ISolver<T, 1> {
       // printf("%i best cost so far %f\n", curIter, bestCostSoFar );
 
       // any further update?
-      if (curIter == this->settings_.maxIter - 2)
+      if (curIter == this->m_stop.iterations - 2)
         break;
 
       // update mean (TODO: matrix-vec-multiplication with permutation matrix?)

--- a/include/cppoptlib/solver/conjugatedgradientdescentsolver.h
+++ b/include/cppoptlib/solver/conjugatedgradientdescentsolver.h
@@ -19,19 +19,16 @@ class ConjugatedGradientDescentSolver : public ISolver<T, 1> {
    * @param objFunc [description]
    */
   void minimize(Problem<T> &objFunc, Vector<T> & x0) {
-
-    size_t iter = 0;
-    T gradNorm = 0;
-
     Vector<T> grad(x0.rows());
     Vector<T> grad_old(x0.rows());
     Vector<T> Si(x0.rows());
     Vector<T> Si_old(x0.rows());
 
+    this->m_current.reset();
     do {
       objFunc.gradient(x0, grad);
 
-      if (iter == 0) {
+      if (this->m_current.iterations == 0) {
         Si = -grad;
       } else {
         const double beta = grad.dot(grad) / (grad_old.dot(grad_old));
@@ -45,11 +42,11 @@ class ConjugatedGradientDescentSolver : public ISolver<T, 1> {
       grad_old = grad;
       Si_old = Si;
 
-      gradNorm = grad.template lpNorm<Eigen::Infinity>();
+      this->m_current.gradNorm = grad.template lpNorm<Eigen::Infinity>();
       // std::cout << "iter: "<<iter<< " f = " <<  objFunc.value(x0) << " ||g||_inf "<<gradNorm   << std::endl;
-      iter++;
-
-    } while ((gradNorm > this->settings_.gradTol) && (iter < this->settings_.maxIter));
+      ++this->m_current.iterations;
+      this->m_status = checkConvergence(this->m_stop, this->m_current);
+    } while (this->m_status == Status::Continue);
 
   }
 

--- a/include/cppoptlib/solver/gradientdescentsolver.h
+++ b/include/cppoptlib/solver/gradientdescentsolver.h
@@ -11,7 +11,7 @@ namespace cppoptlib {
 template<typename T>
 class GradientDescentSolver : public ISolver<T, 1> {
 
- public:
+public:
   /**
    * @brief minimize
    * @details [long description]
@@ -21,17 +21,21 @@ class GradientDescentSolver : public ISolver<T, 1> {
   void minimize(Problem<T> &objFunc, Vector<T> & x0) {
 
     Vector<T> direction(x0.rows());
-    size_t iter = 0;
-    T gradNorm = 0;
+    this->m_current.reset();
     do {
       objFunc.gradient(x0, direction);
       const T rate = MoreThuente<T, decltype(objFunc), 1>::linesearch(x0, -direction, objFunc) ;
       x0 = x0 - rate * direction;
-      gradNorm = direction.template lpNorm<Eigen::Infinity>();
+      this->m_current.gradNorm = direction.template lpNorm<Eigen::Infinity>();
       // std::cout << "iter: "<<iter<< " f = " <<  objFunc.value(x0) << " ||g||_inf "<<gradNorm  << std::endl;
-      iter++;
-    } while ((gradNorm > this->settings_.gradTol) && (iter < this->settings_.maxIter));
-
+      ++this->m_current.iterations;
+      this->m_status = checkConvergence(this->m_stop, this->m_current);
+    } while (this->m_status == Status::Continue);
+    if (this->m_debug > DebugLevel::None) {
+        std::cout << "Stop status was: " << this->m_status << std::endl;
+        std::cout << "Stop criteria were: " << std::endl << this->m_stop << std::endl;
+        std::cout << "Current values are: " << std::endl << this->m_current << std::endl;
+    }
   }
 
 };

--- a/include/cppoptlib/solver/isolver.h
+++ b/include/cppoptlib/solver/isolver.h
@@ -11,25 +11,41 @@ namespace cppoptlib {
 
 template<typename T, int Ord>
 class ISolver {
+public:
+    typedef Criteria<T> TCriteria;
+
 protected:
-  const int order_ = Ord;
- public:
-  Options settings_;
+    const int order_ = Ord;
+    TCriteria m_stop, m_current;
+    Status m_status = Status::NotStarted;
+    DebugLevel m_debug = DebugLevel::None;
 
-  ISolver() {
-    settings_ = Options();
-  }
+public:
+    ISolver() {
+        m_stop = TCriteria::defaults();
+        m_current.reset();
+    }
 
-  /**
-   * @brief minimize an objective function given a gradient (and optinal a hessian)
-   * @details this is just the abstract interface
-   *
-   * @param x0 starting point
-   * @param funObjective objective function
-   * @param funGradient gradient function
-   * @param funcHession hessian function
-   */
-  virtual void minimize(Problem<T> &objFunc, Vector<T> & x0) = 0;
+    ISolver(const TCriteria &s) {
+        m_stop = s;
+        m_current.reset();
+    }
+
+    void setStopCriteria(const TCriteria &s) { m_stop = s; }
+    const TCriteria &criteria() { return m_current; }
+    const Status &status() { return m_status; }
+    void setDebug(const DebugLevel &d) { m_debug = d; }
+
+    /**
+     * @brief minimize an objective function given a gradient (and optinal a hessian)
+     * @details this is just the abstract interface
+     *
+     * @param x0 starting point
+     * @param funObjective objective function
+     * @param funGradient gradient function
+     * @param funcHession hessian function
+     */
+    virtual void minimize(Problem<T> &objFunc, Vector<T> & x0) = 0;
 
 };
 

--- a/include/cppoptlib/solver/lbfgsbsolver.h
+++ b/include/cppoptlib/solver/lbfgsbsolver.h
@@ -19,6 +19,7 @@ class LbfgsbSolver : public ISolver<Dtype, 1> {
   Vector<Dtype> uboundTemplate;
   Dtype theta;
   int DIM;
+  int m_historySize = 5;
 
   /**
    * @brief sort pairs (k,v) according v ascending
@@ -195,8 +196,9 @@ class LbfgsbSolver : public ISolver<Dtype, 1> {
     }
   }
  public:
+  void setHistorySize(const int hs) { m_historySize = hs; }
+
   void minimize(Problem<Dtype> &objFunc, Vector<Dtype> & x0) {
-    const int m = 5; // History size
     objFunc_ = &objFunc;
     DIM = x0.rows();
     if (objFunc.hasLowerBound()) {
@@ -250,12 +252,12 @@ class LbfgsbSolver : public ISolver<Dtype, 1> {
       Dtype test = newS.dot(newY);
       test = (test < 0) ? -1.0 * test : test;
       if (test > 1e-7 * newY.squaredNorm()) {
-        if (yHistory.cols() < m) {
+        if (yHistory.cols() < m_historySize) {
           yHistory.conservativeResize(DIM, this->m_current.iterations + 1);
           sHistory.conservativeResize(DIM, this->m_current.iterations + 1);
         } else {
-          yHistory.leftCols(m - 1) = yHistory.rightCols(m - 1).eval();
-          sHistory.leftCols(m - 1) = sHistory.rightCols(m - 1).eval();
+          yHistory.leftCols(m_historySize - 1) = yHistory.rightCols(m_historySize - 1).eval();
+          sHistory.leftCols(m_historySize - 1) = sHistory.rightCols(m_historySize - 1).eval();
         }
         yHistory.rightCols(1) = newY;
         sHistory.rightCols(1) = newS;

--- a/include/cppoptlib/solver/lbfgssolver.h
+++ b/include/cppoptlib/solver/lbfgssolver.h
@@ -26,13 +26,11 @@ class LbfgsSolver : public ISolver<T, 1> {
         Vector<T> x_old = x0;
         Vector<T> x_old2 = x0;
 
-        size_t iter = 0, j = 0, globIter = 0;
+        size_t iter = 0, globIter = 0;
         double H0k = 1;
 
-        T gradNorm = 0;
-
+        this->m_current.reset();
         do {
-
             const T relativeEpsilon = static_cast<T>(0.0001) * std::max(static_cast<T>(1.0), x0.norm());
 
             if (grad.norm() < relativeEpsilon)
@@ -99,15 +97,15 @@ class LbfgsSolver : public ISolver<T, 1> {
             H0k = y.dot(s) / static_cast<double>(y.dot(y));
 
             x_old = x0;
-            gradNorm = grad.template lpNorm<Eigen::Infinity>();
             // std::cout << "iter: "<<globIter<< ", f = " <<  objFunc.value(x0) << ", ||g||_inf "
             // <<gradNorm  << std::endl;
 
             iter++;
             globIter++;
-            j++;
-
-        } while ((gradNorm > this->settings_.gradTol) && (j < this->settings_.maxIter));
+            ++this->m_current.iterations;
+            this->m_current.gradNorm = grad.template lpNorm<Eigen::Infinity>();
+            this->m_status = checkConvergence(this->m_stop, this->m_current);
+        } while (this->m_status == Status::Continue);
 
     }
 

--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -52,7 +52,7 @@ class NelderMeadSolver : public ISolver<T, 0> {
     sort(index.begin(), index.end(), [&](int a, int b)-> bool { return f[a] < f[b]; });
 
     int iter = 0;
-    const int maxIter = this->settings_.maxIter*DIM;
+    const int maxIter = this->m_stop.iterations*DIM;
     while (iter < maxIter) {
 
       // conv-check

--- a/include/cppoptlib/solver/newtondescentsolver.h
+++ b/include/cppoptlib/solver/newtondescentsolver.h
@@ -21,7 +21,7 @@ class NewtonDescentSolver : public ISolver<T, 2> {
 
         T gradNorm = 0;
 
-        size_t iter = 0;
+        this->m_current.reset();
         do {
             objFunc.gradient(x0, grad);
             objFunc.hessian(x0, hessian);
@@ -30,11 +30,11 @@ class NewtonDescentSolver : public ISolver<T, 2> {
 
             const double rate = Armijo<T, decltype(objFunc), 1>::linesearch(x0, delta_x, objFunc) ;
             x0 = x0 + rate * delta_x;
-            gradNorm = grad.template lpNorm<Eigen::Infinity>();
             // std::cout << "iter: "<<iter<< ", f = " <<  objFunc.value(x0) << ", ||g||_inf "<<gradNorm  << std::endl;
-            iter++;
-
-        } while ((gradNorm > this->settings_.gradTol) && (iter < this->settings_.maxIter));
+            ++this->m_current.iterations;
+            this->m_current.gradNorm = grad.template lpNorm<Eigen::Infinity>();
+            this->m_status = checkConvergence(this->m_stop, this->m_current);
+        } while (this->m_status == Status::Continue);
     }
 };
 


### PR DESCRIPTION
Hi,
By looking at some other solvers I finally realised that the Options struct should really be called Criteria. I then added a Status enum and generalised the checkConvergence function in meta.h to use the stopping Criteria and return the Status. Then I made most of the solvers use this function and added utility functions to e.g. print Status codes.

There is then a minor edit as a second commit that allows the user to change the history size (m) for LBFGSB, as this is a property of the solver and not something to do with convergence.

This is based of the gtest branch as that is the only way I can run the tests.

Cheers!