### PR TITLE
Define EXPECT_NEAR if gtest not included

### DIFF
--- a/include/cppoptlib/problem.h
+++ b/include/cppoptlib/problem.h
@@ -5,10 +5,8 @@
 
 #include <Eigen/Dense>
 
-#if defined(MATLAB) || defined(NDEBUG)
+#if defined(MATLAB) || defined(NDEBUG) || !defined(EXPECT_NEAR)
 #define EXPECT_NEAR(x, y, z)
-#else
-#include "../gtest/googletest/include/gtest/gtest.h"
 #endif /* RELEASE MODE */
 
 #include "meta.h"


### PR DESCRIPTION
Files in tests folder include gtest befor all other staff and it defines EXPECT_NEAR. If gtest isn't included then define it to allow compilation in debug mode.