### PR TITLE
Added stop criteria, initial simplex method, and detailed callback to NelderMeadSolver

### DIFF
--- a/include/cppoptlib/meta.h
+++ b/include/cppoptlib/meta.h
@@ -2,6 +2,7 @@
 #ifndef META_H
 #define META_H
 
+#include <string>
 #include <iostream>
 #include <Eigen/Core>
 
@@ -22,8 +23,49 @@ enum class Status {
     XDeltaTolerance,
     FDeltaTolerance,
     GradNormTolerance,
-    Condition
+    Condition,
+    UserDefined
 };
+
+enum class SimplexOp {
+  Place,
+  Reflect,
+  Expand,
+  ContractIn,
+  ContractOut,
+  Shrink
+};
+
+inline std::ostream &operator<<(std::ostream &os, const SimplexOp &op) {
+  switch (op) {
+    case SimplexOp::Place: os << "place"; break;
+    case SimplexOp::Reflect:   os << "reflect"; break;
+    case SimplexOp::Expand:   os << "expand"; break;
+    case SimplexOp::ContractIn:   os << "contract-in"; break;
+    case SimplexOp::ContractOut:   os << "contract-out"; break;
+    case SimplexOp::Shrink:   os << "shrink"; break;
+  }
+  return os;
+}
+
+std::string op_to_string(SimplexOp op) {
+  switch (op) {
+    case SimplexOp::Place:
+      return "place";
+    case SimplexOp::Expand:
+      return "expand";
+    case SimplexOp::Reflect:
+      return "reflect";
+    case SimplexOp::ContractIn:
+      return "contract-in";
+    case SimplexOp::ContractOut:
+      return "contract-out";
+    case SimplexOp::Shrink:
+      return "shrink";
+  }
+  return "unknown";
+}
+
 
 template<typename T>
 class Criteria {
@@ -95,6 +137,7 @@ inline std::ostream &operator<<(std::ostream &os, const Status &s) {
         case Status::FDeltaTolerance: os << "Change in cost function value too small."; break;
         case Status::GradNormTolerance: os << "Gradient vector norm too small."; break;
         case Status::Condition: os << "Condition of Hessian/Covariance matrix too large."; break;
+        case Status::UserDefined: os << "Stop condition defined in the callback."; break;
     }
     return os;
 }

--- a/include/cppoptlib/meta.h
+++ b/include/cppoptlib/meta.h
@@ -66,7 +66,6 @@ std::string op_to_string(SimplexOp op) {
   return "unknown";
 }
 
-
 template<typename T>
 class Criteria {
 public:

--- a/include/cppoptlib/problem.h
+++ b/include/cppoptlib/problem.h
@@ -18,14 +18,22 @@ class Problem {
   using THessian  = Eigen::Matrix<Scalar, Dim, Dim>;
   using TCriteria = Criteria<Scalar>;
   using TIndex = typename TVector::Index;
+  using MatrixType = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
 
  public:
   Problem() {}
   virtual ~Problem()= default;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
   virtual bool callback(const Criteria<Scalar> &state, const TVector &x) {
     return true;
   }
+
+  virtual bool detailed_callback(const Criteria<Scalar> &state, SimplexOp op, int index, const MatrixType &x, std::vector<Scalar> f) {
+    return true;
+  }
+#pragma GCC diagnostic pop
 
   /**
    * @brief returns objective value in x

--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -5,7 +5,6 @@
 #include <Eigen/Core>
 #include "isolver.h"
 #include "../meta.h"
-using namespace std;
 
 namespace cppoptlib {
 
@@ -21,12 +20,12 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
   Status stop_condition;
   bool initialSimplexCreated = false;
 
-  MatrixType makeInitialSimplex (TVector &x) {
+  MatrixType makeInitialSimplex(TVector &x) {
     size_t DIM = x.rows();
 
     MatrixType s = MatrixType::Zero(DIM, DIM + 1);
-    for (int c = 0; c < (int)DIM + 1; ++c) {
-      for (int r = 0; r < (int)DIM; ++r) {
+    for (int c = 0; c < int(DIM) + 1; ++c) {
+      for (int r = 0; r < int(DIM); ++r) {
         s(r, c) = x(r);
         if (r == c - 1) {
           if (x(r) == 0) {
@@ -62,7 +61,7 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
     // compute function values
     std::vector<Scalar> f; f.resize(DIM + 1);
     std::vector<int> index; index.resize(DIM + 1);
-    for (int i = 0; i < (int)DIM + 1; ++i) {
+    for (int i = 0; i < int(DIM) + 1; ++i) {
       f[i] = objFunc(static_cast<TVector >(x0.col(i)));
       index[i] = i;
     }
@@ -78,7 +77,7 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
       // conv-check
       Scalar max1 = fabs(f[index[1]] - f[index[0]]);
       Scalar max2 = (x0.col(index[1]) - x0.col(index[0]) ).array().abs().maxCoeff();
-      for (int i = 2; i < (int)DIM + 1; ++i) {
+      for (int i = 2; i < int(DIM) + 1; ++i) {
         Scalar tmp1 = fabs(f[index[i]] - f[index[0]]);
         if (tmp1 > max1)
           max1 = tmp1;
@@ -120,7 +119,7 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
 
       // midpoint of the simplex opposite the worst point
       TVector x_bar = TVector::Zero(DIM);
-      for (int i = 0; i < (int)DIM; ++i) {
+      for (int i = 0; i < int(DIM); ++i) {
         x_bar += x0.col(index[i]);
       }
       x_bar /= Scalar(DIM);

--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <Eigen/Core>
 #include "isolver.h"
+#include "../meta.h"
+using namespace std;
 
 namespace cppoptlib {
 
@@ -14,13 +16,37 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
   using typename Superclass::Scalar;
   using typename Superclass::TVector;
   using MatrixType = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+  MatrixType x0;
+  SimplexOp lastOp = SimplexOp::Place;
+  Status stop_condition;
+  bool initialSimplexCreated = false;
+
+  MatrixType makeInitialSimplex (TVector &x) {
+    size_t DIM = x.rows();
+
+    MatrixType s = MatrixType::Zero(DIM, DIM + 1);
+    for (int c = 0; c < (int)DIM + 1; ++c) {
+      for (int r = 0; r < (int)DIM; ++r) {
+        s(r, c) = x(r);
+        if (r == c - 1) {
+          if (x(r) == 0) {
+            s(r, c) = 0.00025;
+          }
+          s(r, c) = (1 + 0.05) * x(r);
+        }
+      }
+    }
+
+    return s;
+  }
+
   /**
    * @brief minimize
    * @details [long description]
    *
    * @param objFunc [description]
    */
-  void minimize(ProblemType &objFunc, TVector & x) {
+  void minimize(ProblemType &objFunc, TVector &x) {
 
     const Scalar rho = 1.;    // rho > 0
     const Scalar xi  = 2.;    // xi  > max(rho, 1)
@@ -29,25 +55,14 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
     const size_t DIM = x.rows();
 
     // create initial simplex
-    MatrixType x0 = MatrixType::Zero(DIM, DIM + 1);
-    for (int c = 0; c < DIM + 1; ++c) {
-      for (int r = 0; r < DIM; ++r) {
-        x0(r, c) = x(r);
-        if (r == c - 1) {
-          if (x(r) == 0) {
-            x0(r, c) = 0.00025;
-          } else {
-
-          }
-          x0(r, c) = (1 + 0.05) * x(r);
-        }
-      }
+    if (not initialSimplexCreated) {
+      x0 = makeInitialSimplex(x);
     }
 
     // compute function values
     std::vector<Scalar> f; f.resize(DIM + 1);
     std::vector<int> index; index.resize(DIM + 1);
-    for (int i = 0; i < DIM + 1; ++i) {
+    for (int i = 0; i < (int)DIM + 1; ++i) {
       f[i] = objFunc(static_cast<TVector >(x0.col(i)));
       index[i] = i;
     }
@@ -55,13 +70,15 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
     sort(index.begin(), index.end(), [&](int a, int b)-> bool { return f[a] < f[b]; });
 
     int iter = 0;
-    const int maxIter = this->m_stop.iterations*DIM;
-    while (objFunc.callback(this->m_current, x0.col(index[0])) && (iter < maxIter)) {
-
+    const int maxIter = this->m_stop.iterations * DIM;
+    while (
+      objFunc.callback(this->m_current, x0.col(index[0])) and
+      (iter < maxIter)
+    ) {
       // conv-check
       Scalar max1 = fabs(f[index[1]] - f[index[0]]);
       Scalar max2 = (x0.col(index[1]) - x0.col(index[0]) ).array().abs().maxCoeff();
-      for (int i = 2; i < DIM + 1; ++i) {
+      for (int i = 2; i < (int)DIM + 1; ++i) {
         Scalar tmp1 = fabs(f[index[i]] - f[index[0]]);
         if (tmp1 > max1)
           max1 = tmp1;
@@ -74,10 +91,27 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
       const Scalar tt2 = std::max(Scalar(1.e-04), 10 * (std::nextafter(x0.col(index[0]).maxCoeff(), std::numeric_limits<Scalar>::epsilon())
                     - x0.col(index[0]).maxCoeff()));
 
+      // User-defined stopping criteria
+      this->m_current.iterations = iter;
+      this->m_current.fDelta = max1;
+      this->m_current.xDelta = max2;
+      stop_condition = checkConvergence(this->m_stop, this->m_current);
+      if (this->m_stop.iterations != 0 and stop_condition != Status::Continue) {
+        break;
+      }
+
+      // Allow stopping in the callback. This callback gets the correct current
+      // state unlike the simple one in while(), which get previous state.
+      if (objFunc.detailed_callback(this->m_current, lastOp, index[0], x0, f) == false) {
+        stop_condition = Status::UserDefined;
+        break;
+      }
+
       // max(||x - shift(x) ||_inf ) <= tol,
       if (max1 <=  tt1) {
         // values to similar
         if (max2 <= tt2) {
+          stop_condition = Status::FDeltaTolerance;
           break;
         }
       }
@@ -86,7 +120,7 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
 
       // midpoint of the simplex opposite the worst point
       TVector x_bar = TVector::Zero(DIM);
-      for (int i = 0; i < DIM; ++i) {
+      for (int i = 0; i < (int)DIM; ++i) {
         x_bar += x0.col(index[i]);
       }
       x_bar /= Scalar(DIM);
@@ -94,6 +128,7 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
       // Compute the reflection point
       const TVector x_r   = ( 1. + rho ) * x_bar - rho   * x0.col(index[DIM]);
       const Scalar f_r = objFunc(x_r);
+      lastOp = SimplexOp::Reflect;
 
       if (f_r < f[index[0]]) {
         // the expansion point
@@ -101,10 +136,12 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
         const Scalar f_e = objFunc(x_e);
         if ( f_e < f_r ) {
           // expand
+          lastOp = SimplexOp::Expand;
           x0.col(index[DIM]) = x_e;
           f[index[DIM]] = f_e;
         } else {
           // reflect
+          lastOp = SimplexOp::Reflect;
           x0.col(index[DIM]) = x_r;
           f[index[DIM]] = f_r;
         }
@@ -121,8 +158,10 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
               // outside
               x0.col(index[DIM]) = x_c;
               f[index[DIM]] = f_c;
+              lastOp = SimplexOp::ContractOut;
             } else {
               shrink(x0, index, f, objFunc);
+              lastOp = SimplexOp::Shrink;
             }
           } else {
             // inside
@@ -131,20 +170,30 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
             if (f_c < f[index[DIM]]) {
               x0.col(index[DIM]) = x_c;
               f[index[DIM]] = f_c;
+              lastOp = SimplexOp::ContractIn;
             } else {
               shrink(x0, index, f, objFunc);
+              lastOp = SimplexOp::Shrink;
             }
           }
         }
       }
       sort(index.begin(), index.end(), [&](int a, int b)-> bool { return f[a] < f[b]; });
       iter++;
-    }
+      if (iter >= maxIter) {
+        stop_condition = Status::IterationLimit;
+      }
+      else {
+        stop_condition = Status::UserDefined; // if stopped in the callback in while()
+      }
+    } // while loop
+
+    // report the last result
+    objFunc.detailed_callback(this->m_current, lastOp, index[0], x0, f);
     x = x0.col(index[0]);
   }
 
   void shrink(MatrixType &x, std::vector<int> &index, std::vector<Scalar> &f, ProblemType &objFunc) {
-
     const Scalar sig = 0.5;   // 0 < sig < 1
     const int DIM = x.rows();
     f[index[0]] = objFunc(x.col(index[0]));
@@ -152,10 +201,24 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
       x.col(index[i]) = sig * x.col(index[i]) + (1. - sig) * x.col(index[0]);
       f[index[i]] = objFunc(x.col(index[i]));
     }
-
   }
 
-};
+  // Need our own checker here to get rid of the gradient test used in other solvers
+  template<typename T>
+  Status checkConvergence(const Criteria<T> &stop, const Criteria<T> &current) {
+    if ((stop.iterations > 0) && (current.iterations > stop.iterations)) {
+      return Status::IterationLimit;
+    }
+    if ((stop.xDelta > 0) && (current.xDelta < stop.xDelta)) {
+      return Status::XDeltaTolerance;
+    }
+    if ((stop.fDelta > 0) && (current.fDelta < stop.fDelta)) {
+      return Status::FDeltaTolerance;
+    }
+    return Status::Continue;
+  }
+
+}; /* class NelderMeadSolver */
 
 } /* namespace cppoptlib */
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-SET( EXAMPLE_FILES linearregression logisticregression rosenbrock rosenbrock_float simple simple_withoptions nonnegls)
+SET( EXAMPLE_FILES linearregression logisticregression rosenbrock rosenbrock_float simple simple_withoptions nonnegls neldermead neldermead-customized)
 
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/examples )
 foreach( currentfile ${EXAMPLE_FILES} )

--- a/src/examples/neldermead-customized.cpp
+++ b/src/examples/neldermead-customized.cpp
@@ -6,10 +6,8 @@
 #include "../../include/cppoptlib/problem.h"
 #include "../../include/cppoptlib/solver/neldermeadsolver.h"
 
-
-static ofstream trace_stream;
+static std::ofstream trace_stream;
 static bool first_iteration = true; // to help generate trace JSON
-
 
 // to use this library just use the namespace "cppoptlib"
 namespace cppoptlib {
@@ -34,14 +32,14 @@ namespace cppoptlib {
 
       //   // Be mindful of calls to value() in the callback if the function is
       //   // computationally intensive.expensive. Consider using detailed_callback().
-      //   std::cout << setw(6) << state.iterations << setw(12) << a[0] << setw(12) << a[1] << setw(12) << value(x) << std::endl;
+      //   std::cout << std::setw(6) << state.iterations << std::setw(12) << a[0] << std::setw(12) << a[1] << std::setw(12) << value(x) << std::endl;
       //   return true;
       // }
 
-      bool detailed_callback(const cppoptlib::Criteria<T> &state, SimplexOp op, int index, const MatrixType &x, vector<Scalar> f) {
+      bool detailed_callback(const cppoptlib::Criteria<T> &state, SimplexOp op, int index, const MatrixType &x, std::vector<Scalar> f) {
         TVector xp = x.col(index).transpose();
 
-        std::cout << setw(6) << state.iterations << setw(12) << xp[0] << setw(12) << xp[1] << setw(12) << f[index] << std::endl;
+        std::cout << std::setw(6) << state.iterations << std::setw(12) << xp[0] << std::setw(12) << xp[1] << std::setw(12) << f[index] << std::endl;
 
         // Write simplex trace
         TVector x0 = x.col(0).transpose();
@@ -75,13 +73,13 @@ namespace cppoptlib {
       using typename Superclass::TVector;
       using MatrixType = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
 
-      MatrixType makeInitialSimplex (TVector &x) {
+      MatrixType makeInitialSimplex(TVector &x) {
         size_t dim = x.rows();
 
         // create initial simplex
         MatrixType s = MatrixType::Zero(dim, dim + 1);
-        for (int c = 0; c < (int)dim + 1; ++c) {
-          for (int r = 0; r < (int)dim; ++r) {
+        for (int c = 0; c < int(dim) + 1; ++c) {
+          for (int r = 0; r < int(dim); ++r) {
             s(r, c) = x(r);
             if (r == c - 1) {
               s(r, c) = x(r) + 0.5;
@@ -95,10 +93,6 @@ namespace cppoptlib {
   };
 }
 
-
-/**
- * @function main
- */
 int main( int argc, char** argv ) {
   typedef double T;
   typedef cppoptlib::Rosenbrock<T> Rosenbrock;
@@ -122,7 +116,7 @@ int main( int argc, char** argv ) {
   solver.x0 = solver.makeInitialSimplex(x);
 
   // Write simplex trace (most of it will be written by the callback)
-  trace_stream.open("simplex-trace.json", ofstream::out);
+  trace_stream.open("simplex-trace.json", std::ofstream::out);
   trace_stream <<
     "{\n"
     "  \"simplex\": [\n";
@@ -139,11 +133,11 @@ int main( int argc, char** argv ) {
   trace_stream.close();
 
   // Print results
-  std::cout << string(42, '-') << std::endl;
+  std::cout << std::string(42, '-') << std::endl;
   std::cout << "   stop:" << "  " << solver.stop_condition << std::endl;
   std::cout << "   argmin: " << x.transpose() << std::endl;
   std::cout << "   f in argmin: " << f(x) << std::endl;
-  std::cout << "   trace written to simplex-trace.json" << endl;
+  std::cout << "   trace written to simplex-trace.json" << std::endl;
 
   return 0;
 }

--- a/src/examples/neldermead-customized.cpp
+++ b/src/examples/neldermead-customized.cpp
@@ -1,0 +1,149 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
+#include "../../include/cppoptlib/meta.h"
+#include "../../include/cppoptlib/problem.h"
+#include "../../include/cppoptlib/solver/neldermeadsolver.h"
+
+
+static ofstream trace_stream;
+static bool first_iteration = true; // to help generate trace JSON
+
+
+// to use this library just use the namespace "cppoptlib"
+namespace cppoptlib {
+
+  // we define a new problem for optimizing the rosenbrock function
+  // we use a templated-class rather than "auto"-lambda function for a clean architecture
+  template<typename T> class Rosenbrock : public Problem<T, 2> {
+    public:
+      using typename Problem<T, 2>::TVector;
+      using typename Problem<T, 2>::Scalar;
+      using MatrixType = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+
+      // this is just the objective (NOT optional)
+      T value(const TVector &x) {
+        const T t1 = (1 - x[0]);
+        const T t2 = (x[1] - x[0] * x[0]);
+        return   t1 * t1 + 100 * t2 * t2;
+      }
+
+      // bool callback(const cppoptlib::Criteria<T> &state, const TVector &x) {
+      //   TVector a = x.transpose();
+
+      //   // Be mindful of calls to value() in the callback if the function is
+      //   // computationally intensive.expensive. Consider using detailed_callback().
+      //   std::cout << setw(6) << state.iterations << setw(12) << a[0] << setw(12) << a[1] << setw(12) << value(x) << std::endl;
+      //   return true;
+      // }
+
+      bool detailed_callback(const cppoptlib::Criteria<T> &state, SimplexOp op, int index, const MatrixType &x, vector<Scalar> f) {
+        TVector xp = x.col(index).transpose();
+
+        std::cout << setw(6) << state.iterations << setw(12) << xp[0] << setw(12) << xp[1] << setw(12) << f[index] << std::endl;
+
+        // Write simplex trace
+        TVector x0 = x.col(0).transpose();
+        TVector x1 = x.col(1).transpose();
+        TVector x2 = x.col(2).transpose();
+        trace_stream << (first_iteration ? "" : ",\n") <<
+          "    {\n"
+          "      \"iter\": " << state.iterations << ",\n"
+          "      \"op\": \"" << op << "\",\n"
+          "      \"index\": " << index << ",\n"
+          "      \"x\": [\n"
+          "        [" << x0[0] << ", " << x0[1] << "],\n"
+          "        [" << x1[0] << ", " << x1[1] << "],\n"
+          "        [" << x2[0] << ", " << x2[1] << "]\n"
+          "      ],\n"
+          "      \"f\": [" << f[0] << ", " << f[1] << ", " << f[2] << "],\n"
+          "      \"xDelta\": " << state.xDelta << ",\n"
+          "      \"fDelta\": " << state.fDelta << "\n"
+          "    }";
+        first_iteration = false;
+
+        return true;
+      }
+
+  };
+
+  template <typename ProblemType> class ModifiedNelderMeadSolver: public NelderMeadSolver<ProblemType> {
+    public:
+      using Superclass = ISolver<ProblemType, 0>;
+      using typename Superclass::Scalar;
+      using typename Superclass::TVector;
+      using MatrixType = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+
+      MatrixType makeInitialSimplex (TVector &x) {
+        size_t dim = x.rows();
+
+        // create initial simplex
+        MatrixType s = MatrixType::Zero(dim, dim + 1);
+        for (int c = 0; c < (int)dim + 1; ++c) {
+          for (int r = 0; r < (int)dim; ++r) {
+            s(r, c) = x(r);
+            if (r == c - 1) {
+              s(r, c) = x(r) + 0.5;
+            }
+          }
+        }
+
+        NelderMeadSolver<ProblemType>::initialSimplexCreated = true;
+        return s;
+      }
+  };
+}
+
+
+/**
+ * @function main
+ */
+int main( int argc, char** argv ) {
+  typedef double T;
+  typedef cppoptlib::Rosenbrock<T> Rosenbrock;
+
+  // Initialize the Rosenbrock-problem
+  Rosenbrock f;
+
+  // Choose a starting point
+  Rosenbrock::TVector x(2); x << -1, 2;
+
+  // Choose a solver
+  cppoptlib::ModifiedNelderMeadSolver<Rosenbrock> solver;
+
+  // Create a Criteria class to set the solver's stop conditions
+  Rosenbrock::TCriteria crit = Rosenbrock::TCriteria::defaults();
+  crit.iterations = 100;
+  crit.fDelta = 0.0005;
+  solver.setStopCriteria(crit);
+
+  // Custom method defined in ModifiedNelderMeadSolver above
+  solver.x0 = solver.makeInitialSimplex(x);
+
+  // Write simplex trace (most of it will be written by the callback)
+  trace_stream.open("simplex-trace.json", ofstream::out);
+  trace_stream <<
+    "{\n"
+    "  \"simplex\": [\n";
+
+  // and minimize the function
+  solver.minimize(f, x);
+
+  // Close trace output
+  trace_stream <<
+    "\n"
+    "  ],\n"
+    "  \"stop\": \"" << solver.stop_condition << "\"\n"
+    "}\n";
+  trace_stream.close();
+
+  // Print results
+  std::cout << string(42, '-') << std::endl;
+  std::cout << "   stop:" << "  " << solver.stop_condition << std::endl;
+  std::cout << "   argmin: " << x.transpose() << std::endl;
+  std::cout << "   f in argmin: " << f(x) << std::endl;
+  std::cout << "   trace written to simplex-trace.json" << endl;
+
+  return 0;
+}

--- a/src/examples/neldermead.cpp
+++ b/src/examples/neldermead.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <iomanip>
+
+#include "../../include/cppoptlib/meta.h"
+#include "../../include/cppoptlib/problem.h"
+#include "../../include/cppoptlib/solver/neldermeadsolver.h"
+
+// to use this library just use the namespace "cppoptlib"
+namespace cppoptlib {
+
+  // we define a new problem for optimizing the rosenbrock function
+  // we use a templated-class rather than "auto"-lambda function for a clean architecture
+  template<typename T> class Rosenbrock : public Problem<T, 2> {
+    public:
+      using typename Problem<T, 2>::TVector;
+
+      // this is just the objective (NOT optional)
+      T value(const TVector &x) {
+        const T t1 = (1 - x[0]);
+        const T t2 = (x[1] - x[0] * x[0]);
+        return   t1 * t1 + 100 * t2 * t2;
+      }
+
+      bool callback(const cppoptlib::Criteria<T> &state, const TVector &x) {
+        TVector a = x.transpose();
+
+        // Be mindful of calls to value() in the callback if the function is
+        // computationally intensive.expensive. Consider using detailed_callback().
+        std::cout << setw(6) << state.iterations << setw(12) << a[0] << setw(12) << a[1] << setw(12) << value(x) << std::endl;
+        return true;
+      }
+  };
+}
+
+/**
+ * @function main
+ */
+int main( int argc, char** argv ) {
+  typedef double T;
+  typedef cppoptlib::Rosenbrock<T> Rosenbrock;
+
+  // initialize the Rosenbrock-problem
+  Rosenbrock f;
+
+  // choose a starting point
+  Rosenbrock::TVector x(2); x << -1, 2;
+
+  // choose a solver
+  cppoptlib::NelderMeadSolver<Rosenbrock> solver;
+
+  // and minimize the function
+  solver.minimize(f, x);
+
+  // print argmin
+  std::cout << string(42, '-') << std::endl;
+  std::cout << "   argmin: " << x.transpose() << std::endl;
+  std::cout << "   f in argmin: " << f(x) << std::endl;
+
+  return 0;
+}

--- a/src/examples/neldermead.cpp
+++ b/src/examples/neldermead.cpp
@@ -26,7 +26,7 @@ namespace cppoptlib {
 
         // Be mindful of calls to value() in the callback if the function is
         // computationally intensive.expensive. Consider using detailed_callback().
-        std::cout << setw(6) << state.iterations << setw(12) << a[0] << setw(12) << a[1] << setw(12) << value(x) << std::endl;
+        std::cout << std::setw(6) << state.iterations << std::setw(12) << a[0] << std::setw(12) << a[1] << std::setw(12) << value(x) << std::endl;
         return true;
       }
   };
@@ -52,7 +52,7 @@ int main( int argc, char** argv ) {
   solver.minimize(f, x);
 
   // print argmin
-  std::cout << string(42, '-') << std::endl;
+  std::cout << std::string(42, '-') << std::endl;
   std::cout << "   argmin: " << x.transpose() << std::endl;
   std::cout << "   f in argmin: " << f(x) << std::endl;
 


### PR DESCRIPTION
The most important change in this set is moving initial simplex placement into a template method, makeInitialSimplex(). Because I cannot override a template method (or don't know how), I added a simple dispatch around it. The signal for dispatch is the state of x0 in the solver. If it has been initialized, it is left alone. Otherwise, it is initialised with the template method. That way, in the absence of customizations, there is no change in functionality and the solver works as it did before. I am not sure it is the best way to do it; just the first idea that worked.

There rest of this changeset includes nice things such as configurable stop criteria similar to those used in other solvers and a detailed callback function that allows better inspection of the solver's state.

I haven't figured out the test thing but provided a working example that covers all new features.
