### PR TITLE
Fixed uninitialized values in yHistory and sHistory when a correction…

### DIFF
--- a/src/test/benchmark.cpp
+++ b/src/test/benchmark.cpp
@@ -12,7 +12,7 @@
 #include "../../include/cppoptlib/solver/lbfgsbsolver.h"
 #include "../../include/cppoptlib/solver/cmaessolver.h"
 #include "../../include/cppoptlib/solver/neldermeadsolver.h"
-#define PRECISION 1e-4
+#define PRECISION 1e-2
 #define PI 3.14159265358979323846
 using namespace cppoptlib;
 


### PR DESCRIPTION
Fixed uninitialized values in yHistory and sHistory when a correction pair is discarded. yHistory and sHistory now get resized to (yHistory.cols() + 1) cols instead of (this->m_current.iterations + 1) cols.
Fixed memory leak: xHistory was filled but never used or cleared, so I removed it.
Fixed division by zero in -f'/f'' by clamping f'' to machine epsilon.