### PR TITLE
One definition rule (inline function)

### DIFF
--- a/include/cppoptlib/meta.h
+++ b/include/cppoptlib/meta.h
@@ -48,7 +48,7 @@ inline std::ostream &operator<<(std::ostream &os, const SimplexOp &op) {
   return os;
 }
 
-std::string op_to_string(SimplexOp op) {
+inline std::string op_to_string(SimplexOp op) {
   switch (op) {
     case SimplexOp::Place:
       return "place";


### PR DESCRIPTION
If I end up including meta.h in multiple .cpp files linker complains about multiple definition of the "op_to_string" function. Defining the function as inline fixes the problem.

For more details I add linker error message (visual studio):
Error LNK2005	"class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl cppoptlib::op_to_string(enum cppoptlib::SimplexOp)" (?op_to_string@cppoptlib@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4SimplexOp@1@@Z) already defined in xxx.obj xxx xxx/main.obj 1
(xxx used to hide path+names)