### PR TITLE
Build tweaks

### DIFF
--- a/cmake/Modules/FindEigen3.cmake
+++ b/cmake/Modules/FindEigen3.cmake
@@ -62,6 +62,8 @@ if (EIGEN3_INCLUDE_DIR)
 else (EIGEN3_INCLUDE_DIR)
 
   find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+      HINTS
+      eigen
       PATHS
       ${CMAKE_INSTALL_PREFIX}/include
       ${KDE4_INCLUDE_DIR}

--- a/get_dependencies.sh
+++ b/get_dependencies.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # eigen library
 EIGEN_VERSION="3.2.10"
 curl https://bitbucket.org/eigen/eigen/get/$EIGEN_VERSION.tar.gz | tar xz


### PR DESCRIPTION
Two build tweaks to be able to build on Arch Linux (tested on `Linux karel-work 4.9.8-1-ARCH #1 SMP PREEMPT Mon Feb 6 12:59:40 CET 2017 x86_64 GNU/Linux`), in a `fish` shell.

Unrelated: `./bin/verify` fails with:

```
/home/karel/working/CppNumericalSolvers/src/test/verify.cpp:167: Failure
The difference between 0.0 and f(x) is 0.00045017696304783911, which exceeds 1e-4, where
0.0 evaluates to 0,
f(x) evaluates to 0.00045017696304783911, and
1e-4 evaluates to 0.0001.
[  FAILED  ] CMAesTest/1.RosenbrockNearFull, where TypeParam = double (173 ms)
```
