### PR TITLE
Fix a bug in the NelderMeadSolver

### DIFF
--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -30,8 +30,9 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
         if (r == c - 1) {
           if (x(r) == 0) {
             s(r, c) = 0.00025;
+          } else {
+            s(r, c) = (1 + 0.05) * x(r);
           }
-          s(r, c) = (1 + 0.05) * x(r);
         }
       }
     }

--- a/src/test/verify.cpp
+++ b/src/test/verify.cpp
@@ -142,6 +142,7 @@ TEST(CMAesTest, RosenbrockNearValue)                               { SOLVE_PROBL
 TYPED_TEST(NelderMeadTest, RosenbrockFarValue)                     { SOLVE_PROBLEM(cppoptlib::NelderMeadSolver,RosenbrockValue, 15.0, 8.0, 0.0) }
 TYPED_TEST(NelderMeadTest, RosenbrockNearValue)                    { SOLVE_PROBLEM(cppoptlib::NelderMeadSolver,RosenbrockValue, -1.0, 2.0, 0.0) }
 TYPED_TEST(NelderMeadTest, RosenbrockMixValue)                     { SOLVE_PROBLEM(cppoptlib::NelderMeadSolver,RosenbrockValue, -1.2, 100.0, 0.0) }
+TYPED_TEST(NelderMeadTest, RosenbrockZeroValue)                    { SOLVE_PROBLEM(cppoptlib::NelderMeadSolver,RosenbrockValue, 0.0, 100.0, 0.0) }
 
 // gradient information ( Hessian for newton descent)
 TYPED_TEST(GradientDescentTest, RosenbrockFarGradient)             { SOLVE_PROBLEM(cppoptlib::GradientDescentSolver,RosenbrockGradient, 15.0, 8.0, 0.0) }


### PR DESCRIPTION
This fixes a bug in the `NelderMeadSolver` which generated a simplex with duplicated points when a zeros is passed in the starting vector. As a result the simplex was flat in some dimensions and the NelderMeadSolver wasn't able to solve problems initialized with such starting vectors.

I've added the test `NelderMeadTest.RosenbrockZeroValue` which tests for this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patwie/cppnumericalsolvers/80)
<!-- Reviewable:end -->
