### PR TITLE
Fix an off-by-one error in NelderMeadSolver

### DIFF
--- a/include/cppoptlib/solver/neldermeadsolver.h
+++ b/include/cppoptlib/solver/neldermeadsolver.h
@@ -146,7 +146,7 @@ class NelderMeadSolver : public ISolver<ProblemType, 0> {
           f[index[DIM]] = f_r;
         }
       } else {
-        if ( f_r < f[index[DIM]] ) {
+        if ( f_r < f[index[DIM - 1]] ) {
           x0.col(index[DIM]) = x_r;
           f[index[DIM]] = f_r;
         } else {


### PR DESCRIPTION
f<sub>r</sub> should be compared to f<sub>n</sub> and not f<sub>n+1</sub> do decide if the reflection point is accepted.

A side-effect of this bug was that there were only inside contractions and no outside contractions as the condition for the outside contraction was always false.

FYI: As this code is only executed if DIM >= 1 there shouldn't be any accidental accesses to index -1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patwie/cppnumericalsolvers/83)
<!-- Reviewable:end -->
