### PR TITLE
Improve README section on box-constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ For convenience there are some typedefs:
 ````
 ### using box-constraints
 
-The `L-BFGS-B` algorithm allows to optimize functions with box-constraints, i.e., `min_x f(x) s.t. a <= x <= b` for some `a, b`. Given a `problem`-class you can enter these constraints by
+The `L-BFGS-B` algorithm allows to optimize functions with box-constraints, i.e., `min_x f(x) s.t. a <= x <= b` for some `a, b`. Given a `BoundedProblem`-class you can enter these constraints by
 ````cpp
-    cppoptlib::YourProblem<T> f;
+    cppoptlib::LbfgsSolver<T> f;
     f.setLowerBound(Vector<double>::Zero(DIM));
     f.setUpperBound(Vector<double>::Ones(DIM)*5);
 ````


### PR DESCRIPTION
Minor improvement to the README on the section of box-constraints. Adds hints to look for the `BoundedProblem` class and uses a L-BFGS in the pseudo-example.