### PR TITLE
Expose types only via function and avoid need for template arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ Have you ever looked for a C++ function *fminsearch*, which is easy to use witho
 Want a full example?
 
 ```cpp
-    using Problem = Function<double, /*Order*/ 1, /*InputDim*/ 2>;
-    class Rosenbrock : public Problem {
+    using FunctionXd = cppoptlib::function::Function<double>;
+
+    class Rosenbrock : public FunctionXd {
       public:
 
-        using vector_t = typename Problem::vector_t;
-        using scalar_t = typename Problem::scalar_t;
+        using vector_t = Eigen::VectorXd;
+        using scalar_t = double;
 
         scalar_t operator()(const vector_t &x) {
             const scalar_t t1 = (1 - x[0]);
@@ -29,12 +30,10 @@ Want a full example?
         }
     };
     int main(int argc, char const *argv[]) {
+        using Solver = cppoptlib::solver::Bfgs<Rosenbrock>;
 
-        using Function = Rosenbrock;
-        using Solver = cppoptlib::solver::Bfgs<Function>;
-
-        Function f;
-        Function::vector_t x(2);
+        Rosenbrock f;
+        Rosenbrock::vector_t x(2);
         x << -1, 2;
 
         // Evaluate

--- a/include/cppoptlib/function.h
+++ b/include/cppoptlib/function.h
@@ -9,49 +9,53 @@ namespace cppoptlib {
 namespace function {
 
 // Specifies a current function state.
-template <class scalar_t, class vector_t, class matrix_t, int Ord>
+template <class scalar_t, class vector_t, class matrix_t>
 struct State {
-  scalar_t value = 0;                    // The objective value.
-  vector_t x = vector_t::Zero();         // The current input value in x.
-  vector_t gradient = vector_t::Zero();  // The gradient in x.
-  matrix_t hessian = matrix_t::Zero();   // The Hessian in x;
+  int dim;
+  int order;
 
-  State() {}
+  scalar_t value = 0;  // The objective value.
+  vector_t x;          // The current input value in x.
+  vector_t gradient;   // The gradient in x.
+  matrix_t hessian;    // The Hessian in x;
 
-  State operator=(const State<scalar_t, vector_t, matrix_t, 0> &rhs) {
+  State() : dim(-1), order(-1) {}
+  State(const int dim, const int order)
+      : dim(dim),
+        order(order),
+        x(vector_t::Zero(dim)),
+        gradient(vector_t::Zero(dim)),
+        hessian(matrix_t::Zero(dim, dim)) {}
+
+  State operator=(const State<scalar_t, vector_t, matrix_t> &rhs) {
+    assert(rhs.order > -1);
+    dim = rhs.dim;
+    order = rhs.order;
     value = rhs.value;
     x = rhs.x.eval();
-    return *this;
-  }
-
-  State operator=(const State<scalar_t, vector_t, matrix_t, 1> &rhs) {
-    value = rhs.value;
-    x = rhs.x.eval();
-    gradient = rhs.gradient.eval();
-    return *this;
-  }
-
-  State operator=(const State<scalar_t, vector_t, matrix_t, 2> &rhs) {
-    value = rhs.value;
-    x = rhs.x.eval();
-    gradient = rhs.gradient.eval();
-    hessian = rhs.hessian.eval();
+    if (order >= 1) {
+      gradient = rhs.gradient.eval();
+    }
+    if (order >= 2) {
+      hessian = rhs.hessian.eval();
+    }
     return *this;
   }
 };
 
-template <class TScalar, int Ord = 1, int TDim = Eigen::Dynamic>
+template <class TScalar, int TDim = Eigen::Dynamic>
 class Function {
- public:
+ private:
   static const int Dim = TDim;
-  static const int Order = Ord;
+
+ public:
   using scalar_t = TScalar;
   using vector_t = Eigen::Matrix<TScalar, Dim, 1>;
   using hessian_t = Eigen::Matrix<TScalar, Dim, Dim>;
-  using index_t = typename vector_t::Index;
   using matrix_t = Eigen::Matrix<TScalar, Eigen::Dynamic, Eigen::Dynamic>;
+  using index_t = typename vector_t::Index;
 
-  using state_t = function::State<scalar_t, vector_t, hessian_t, Order>;
+  using state_t = function::State<scalar_t, vector_t, hessian_t>;
 
  public:
   Function() = default;
@@ -69,18 +73,20 @@ class Function {
     utils::ComputeFiniteHessian(*this, x, hessian);
   }
 
+  virtual int Order() const { return 1; }
+
   // For improved performance, this function will return the state directly.
   // Override this method if you can compute the objective value, gradient and
   // Hessian simultaneously.
-  virtual State<scalar_t, vector_t, hessian_t, Ord> Eval(
-      const vector_t &x) const {
-    State<scalar_t, vector_t, hessian_t, Ord> state;
+  virtual State<scalar_t, vector_t, hessian_t> Eval(const vector_t &x,
+                                                    const int order = 2) const {
+    State<scalar_t, vector_t, hessian_t> state(x.rows(), order);
     state.value = this->operator()(x);
     state.x = x;
-    if (Ord >= 1) {
+    if (order >= 1) {
       this->Gradient(x, &state.gradient);
     }
-    if (Ord >= 2) {
+    if (order >= 2) {
       this->Hessian(x, &state.hessian);
     }
     return state;

--- a/include/cppoptlib/solver/bfgs.h
+++ b/include/cppoptlib/solver/bfgs.h
@@ -10,23 +10,27 @@ namespace cppoptlib {
 
 namespace solver {
 template <typename function_t>
-class Bfgs : public Solver<function_t, 1> {
- public:
-  using Superclass = Solver<function_t, 1>;
-  using typename Superclass::state_t;
-  using typename Superclass::scalar_t;
-  using typename Superclass::hessian_t;
-  using typename Superclass::vector_t;
-  using typename Superclass::function_state_t;
+class Bfgs : public Solver<function_t> {
+ private:
+  using Superclass = Solver<function_t>;
+  using state_t = typename Superclass::state_t;
 
+  using scalar_t = typename function_t::scalar_t;
+  using hessian_t = typename function_t::hessian_t;
+  using matrix_t = typename function_t::matrix_t;
+  using vector_t = typename function_t::vector_t;
+  using function_state_t = typename function_t::state_t;
+
+ public:
   void InitializeSolver(const function_state_t &initial_state) override {
+    dim_ = initial_state.x.rows();
     inverse_hessian_ =
         hessian_t::Identity(initial_state.x.rows(), initial_state.x.rows());
   }
 
   function_state_t OptimizationStep(const function_t &function,
                                     const function_state_t &current,
-                                    const state_t &state) override {
+                                    const state_t & /*state*/) override {
     vector_t search_direction = -inverse_hessian_ * current.gradient;
 
     // Check "positive definite".
@@ -35,7 +39,7 @@ class Bfgs : public Solver<function_t, 1> {
     // If not positive definit reinitialize Hessian.
     if ((phi > 0) || (phi != phi)) {
       // no, we reset the hessian approximation
-      inverse_hessian_ = hessian_t::Identity(function_t::Dim, function_t::Dim);
+      inverse_hessian_ = hessian_t::Identity(dim_, dim_);
       search_direction = -current.gradient;
     }
 
@@ -61,6 +65,7 @@ class Bfgs : public Solver<function_t, 1> {
   }
 
  private:
+  int dim_;
   hessian_t inverse_hessian_;
 };
 

--- a/include/cppoptlib/solver/conjugated_gradient_descent.h
+++ b/include/cppoptlib/solver/conjugated_gradient_descent.h
@@ -10,21 +10,25 @@ namespace cppoptlib {
 
 namespace solver {
 template <typename function_t>
-class ConjugatedGradientDescent : public Solver<function_t, 1> {
- public:
-  using Superclass = Solver<function_t, 1>;
-  using typename Superclass::state_t;
-  using typename Superclass::scalar_t;
-  using typename Superclass::vector_t;
-  using typename Superclass::function_state_t;
+class ConjugatedGradientDescent : public Solver<function_t> {
+ private:
+  using Superclass = Solver<function_t>;
+  using state_t = typename Superclass::state_t;
 
+  using scalar_t = typename function_t::scalar_t;
+  using hessian_t = typename function_t::hessian_t;
+  using matrix_t = typename function_t::matrix_t;
+  using vector_t = typename function_t::vector_t;
+  using function_state_t = typename function_t::state_t;
+
+ public:
   void InitializeSolver(const function_state_t &initial_state) override {
     previous_ = initial_state;
   }
 
   function_state_t OptimizationStep(const function_t &function,
-                                     const function_state_t &current,
-                                     const state_t &state) override {
+                                    const function_state_t &current,
+                                    const state_t &state) override {
     if (state.num_iterations == 0) {
       search_direction_ = -current.gradient;
     } else {
@@ -34,16 +38,10 @@ class ConjugatedGradientDescent : public Solver<function_t, 1> {
     }
     previous_ = current;
 
-    function_state_t next = current;
-
     const scalar_t rate = linesearch::Armijo<function_t, 1>::Search(
-        next.x, search_direction_, function);
+        current.x, search_direction_, function);
 
-    next.x = next.x + rate * search_direction_;
-    next.value = function(next.x);
-    function.Gradient(next.x, &next.gradient);
-
-    return next;
+    return function.Eval(current.x + rate * search_direction_, 1);
   }
 
  private:

--- a/include/cppoptlib/solver/gradient_descent.h
+++ b/include/cppoptlib/solver/gradient_descent.h
@@ -10,17 +10,21 @@ namespace cppoptlib {
 
 namespace solver {
 template <typename function_t>
-class GradientDescent : public Solver<function_t, 1> {
- public:
-  using Superclass = Solver<function_t, 1>;
-  using typename Superclass::state_t;
-  using typename Superclass::scalar_t;
-  using typename Superclass::vector_t;
-  using typename Superclass::function_state_t;
+class GradientDescent : public Solver<function_t> {
+ private:
+  using Superclass = Solver<function_t>;
+  using state_t = typename Superclass::state_t;
 
+  using scalar_t = typename function_t::scalar_t;
+  using hessian_t = typename function_t::hessian_t;
+  using matrix_t = typename function_t::matrix_t;
+  using vector_t = typename function_t::vector_t;
+  using function_state_t = typename function_t::state_t;
+
+ public:
   function_state_t OptimizationStep(const function_t &function,
-                                     const function_state_t &current,
-                                     const state_t &state) override {
+                                    const function_state_t &current,
+                                    const state_t & /*state*/) override {
     function_state_t next = current;
 
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(

--- a/include/cppoptlib/solver/newton_descent.h
+++ b/include/cppoptlib/solver/newton_descent.h
@@ -10,23 +10,32 @@ namespace cppoptlib {
 
 namespace solver {
 template <typename function_t>
-class NewtonDescent : public Solver<function_t, 2> {
+class NewtonDescent : public Solver<function_t> {
+ private:
+  using Superclass = Solver<function_t>;
+  using state_t = typename Superclass::state_t;
+
+  using scalar_t = typename function_t::scalar_t;
+  using hessian_t = typename function_t::hessian_t;
+  using matrix_t = typename function_t::matrix_t;
+  using vector_t = typename function_t::vector_t;
+  using function_state_t = typename function_t::state_t;
+
  public:
-  using Superclass = Solver<function_t, 2>;
-  using typename Superclass::Dim;
-  using typename Superclass::state_t;
-  using typename Superclass::scalar_t;
-  using typename Superclass::vector_t;
-  using typename Superclass::hessian_t;
-  using typename Superclass::function_state_t;
+  int Order() const override { return 2; }
+
+  void InitializeSolver(const function_state_t &initial_state) override {
+    dim_ = initial_state.x.rows();
+  }
 
   function_state_t OptimizationStep(const function_t &function,
-                                     const function_state_t &current,
-                                     const state_t &state) override {
+                                    const function_state_t &current,
+                                    const state_t & /*state*/) override {
     function_state_t next = current;
 
     constexpr scalar_t safe_guard = 1e-5;
-    hessian_t hessian = next.hessian + safe_guard * hessian_t::Identity();
+    hessian_t hessian =
+        next.hessian + safe_guard * hessian_t::Identity(dim_, dim_);
 
     const vector_t delta_x = hessian.lu().solve(-next.gradient);
     const scalar_t rate =
@@ -36,6 +45,9 @@ class NewtonDescent : public Solver<function_t, 2> {
 
     return function.Eval(next.x);
   }
+
+ private:
+  int dim_;
 };
 
 }  // namespace solver

--- a/include/cppoptlib/utils/derivatives.h
+++ b/include/cppoptlib/utils/derivatives.h
@@ -4,9 +4,9 @@
 #define INCLUDE_CPPOPTLIB_UTILS_DERIVATIVES_H_
 
 #include <algorithm>
+#include <array>
 #include <limits>
 #include <vector>
-#include <array>
 
 namespace cppoptlib {
 namespace utils {
@@ -222,7 +222,7 @@ bool IsGradientCorrect(const function_t &function,
   for (index_t d = 0; d < D; ++d) {
     scalar_t scale =
         std::max(static_cast<scalar_t>(std::max(fabs(actual_gradient[d]),
-                                               fabs(expected_gradient[d]))),
+                                                fabs(expected_gradient[d]))),
                  scalar_t(1.));
     if (fabs(actual_gradient[d] - expected_gradient[d]) > tolerance * scale)
       return false;
@@ -232,7 +232,8 @@ bool IsGradientCorrect(const function_t &function,
 
 template <class function_t>
 bool IsHessianCorrect(const function_t &function,
-                      const typename function_t::vector_t &x0, int accuracy = 3) {
+                      const typename function_t::vector_t &x0,
+                      int accuracy = 3) {
   constexpr float tolerance = 1e-1;
 
   using scalar_t = typename function_t::scalar_t;
@@ -247,10 +248,10 @@ bool IsHessianCorrect(const function_t &function,
   ComputeFiniteHessian(function, x0, &expected_hessian, accuracy);
   for (index_t d = 0; d < D; ++d) {
     for (index_t e = 0; e < D; ++e) {
-      scalar_t scale =
-          std::max(static_cast<scalar_t>(std::max(fabs(actual_hessian(d, e)),
-                                                 fabs(expected_hessian(d, e)))),
-                   scalar_t(1.));
+      scalar_t scale = std::max(
+          static_cast<scalar_t>(std::max(fabs(actual_hessian(d, e)),
+                                         fabs(expected_hessian(d, e)))),
+          scalar_t(1.));
       if (fabs(actual_hessian(d, e) - expected_hessian(d, e)) >
           tolerance * scale)
         return false;

--- a/src/examples/simple.cc
+++ b/src/examples/simple.cc
@@ -10,17 +10,12 @@
 #include "include/cppoptlib/solver/lbfgsb.h"
 #include "include/cppoptlib/solver/newton_descent.h"
 
-constexpr int Order = 1;
-constexpr int Dim = 2;
+using FunctionXd = cppoptlib::function::Function<double>;
 
-template <typename T>
-using SecondOrderProblem = cppoptlib::function::Function<T, Order, Dim>;
-
-template <typename scalar_t>
-class Simple : public SecondOrderProblem<scalar_t> {
+class Function : public FunctionXd {
  public:
-  using vector_t = typename SecondOrderProblem<scalar_t>::vector_t;
-  using hessian_t = typename SecondOrderProblem<scalar_t>::hessian_t;
+  using FunctionXd::vector_t;
+  using FunctionXd::hessian_t;
 
   scalar_t operator()(const vector_t &x) const override {
     return 5 * x[0] * x[0] + 100 * x[1] * x[1] + 5;
@@ -40,7 +35,6 @@ class Simple : public SecondOrderProblem<scalar_t> {
 };
 
 int main(int argc, char const *argv[]) {
-  using Function = Simple<double>;
   // using Solver = cppoptlib::solver::NewtonDescent<Function>;
   // using Solver = cppoptlib::solver::GradientDescent<Function>;
   // using Solver = cppoptlib::solver::ConjugatedGradientDescent<Function>;
@@ -53,13 +47,14 @@ int main(int argc, char const *argv[]) {
   x << -1, 2;
 
   auto state = f.Eval(x);
+  std::cout << "this" << std::endl;
 
   std::cout << f(x) << std::endl;
   std::cout << state.gradient << std::endl;
   std::cout << state.hessian << std::endl;
 
-  std::cout << cppoptlib::utils::IsGradientCorrect(f, x) << std::endl;
-  std::cout << cppoptlib::utils::IsHessianCorrect(f, x) << std::endl;
+  // std::cout << cppoptlib::utils::IsGradientCorrect(f, x) << std::endl;
+  // std::cout << cppoptlib::utils::IsHessianCorrect(f, x) << std::endl;
 
   Solver solver;
 


### PR DESCRIPTION
Previously, the solvers exposed template parameters from the function.
This is not the case anymore to have a much cleaner design. Further,
this also avoids the need to specify order and dimension as this can be
judged during runtime.