### PR TITLE
Solver fixes and API improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ CppNumericalSolvers.config
 /eigen
 /local
 
-# Matlab 
+# Matlab
 *.m~
 *.mexa64
 *.mexa32
@@ -59,6 +59,7 @@ CppNumericalSolvers.config
 /.idea/
 /.project
 /.settings
+/.vscode/
 /WORKSPACE.user.bzl
 /bazel.iml
 # Ignore all bazel-* symlinks. There is no full list since this can change
@@ -70,3 +71,4 @@ CppNumericalSolvers.config
 /test
 /tester.tar
 tensorflow/solve
+compile_commands.json

--- a/include/cppoptlib/function.h
+++ b/include/cppoptlib/function.h
@@ -57,10 +57,8 @@ struct State {
 
 template <class TScalar, int TDim = Eigen::Dynamic>
 class Function {
- private:
-  static const int Dim = TDim;
-
  public:
+  static constexpr int Dim = TDim;
   using scalar_t = TScalar;
   using vector_t = Eigen::Matrix<TScalar, Dim, 1>;
   using hessian_t = Eigen::Matrix<TScalar, Dim, Dim>;

--- a/include/cppoptlib/linesearch/armijo.h
+++ b/include/cppoptlib/linesearch/armijo.h
@@ -2,9 +2,7 @@
 #ifndef INCLUDE_CPPOPTLIB_LINESEARCH_ARMIJO_H_
 #define INCLUDE_CPPOPTLIB_LINESEARCH_ARMIJO_H_
 
-namespace cppoptlib {
-namespace solver {
-namespace linesearch {
+namespace cppoptlib::solver::linesearch {
 template <typename function_t, int Ord>
 class Armijo {
  public:
@@ -78,9 +76,6 @@ class Armijo<function_t, 2> {
     return alpha;
   }
 };
-
-};  // namespace linesearch
-};  // namespace solver
-}  // namespace cppoptlib
+}  // namespace cppoptlib::solver::linesearch
 
 #endif  // INCLUDE_CPPOPTLIB_LINESEARCH_ARMIJO_H_

--- a/include/cppoptlib/linesearch/more_thuente.h
+++ b/include/cppoptlib/linesearch/more_thuente.h
@@ -6,9 +6,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace cppoptlib {
-namespace solver {
-namespace linesearch {
+namespace cppoptlib::solver::linesearch {
 
 template <typename Function, int Ord>
 class MoreThuente {
@@ -315,8 +313,6 @@ class MoreThuente {
     return 0;
   }
 };
-}  // namespace linesearch
-}  // namespace solver
-}  // namespace cppoptlib
+}  // namespace cppoptlib::solver::linesearch
 
 #endif  // INCLUDE_CPPOPTLIB_LINESEARCH_MORE_THUENTE_H_

--- a/include/cppoptlib/solver/bfgs.h
+++ b/include/cppoptlib/solver/bfgs.h
@@ -2,6 +2,8 @@
 #ifndef INCLUDE_CPPOPTLIB_SOLVER_BFGS_H_
 #define INCLUDE_CPPOPTLIB_SOLVER_BFGS_H_
 
+#include <utility>
+
 #include "../linesearch/more_thuente.h"
 #include "Eigen/Core"
 #include "solver.h"  // NOLINT
@@ -21,6 +23,12 @@ class Bfgs : public Solver<function_t> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit Bfgs(const State<scalar_t> &stopping_state =
+                    DefaultStoppingSolverState<scalar_t>(),
+                typename Superclass::callback_t step_callback =
+                    GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
+      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
 
   void InitializeSolver(const function_state_t &initial_state) override {
     dim_ = initial_state.x.rows();

--- a/include/cppoptlib/solver/conjugated_gradient_descent.h
+++ b/include/cppoptlib/solver/conjugated_gradient_descent.h
@@ -2,6 +2,8 @@
 #ifndef INCLUDE_CPPOPTLIB_SOLVER_CONJUGATED_GRADIENT_DESCENT_H_
 #define INCLUDE_CPPOPTLIB_SOLVER_CONJUGATED_GRADIENT_DESCENT_H_
 
+#include <utility>
+
 #include "../linesearch/armijo.h"
 #include "Eigen/Core"
 #include "solver.h"  // NOLINT
@@ -21,6 +23,13 @@ class ConjugatedGradientDescent : public Solver<function_t> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit ConjugatedGradientDescent(
+      const State<scalar_t> &stopping_state =
+          DefaultStoppingSolverState<scalar_t>(),
+      typename Superclass::callback_t step_callback =
+          GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
+      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
 
   void InitializeSolver(const function_state_t &initial_state) override {
     previous_ = initial_state;

--- a/include/cppoptlib/solver/gradient_descent.h
+++ b/include/cppoptlib/solver/gradient_descent.h
@@ -2,6 +2,8 @@
 #ifndef INCLUDE_CPPOPTLIB_SOLVER_GRADIENT_DESCENT_H_
 #define INCLUDE_CPPOPTLIB_SOLVER_GRADIENT_DESCENT_H_
 
+#include <utility>
+
 #include "../linesearch/more_thuente.h"
 #include "Eigen/Core"
 #include "solver.h"  // NOLINT
@@ -21,6 +23,13 @@ class GradientDescent : public Solver<function_t> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit GradientDescent(
+      const State<scalar_t> &stopping_state =
+          DefaultStoppingSolverState<scalar_t>(),
+      typename Superclass::callback_t step_callback =
+          GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
+      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
 
   function_state_t OptimizationStep(const function_t &function,
                                     const function_state_t &current,

--- a/include/cppoptlib/solver/lbfgs.h
+++ b/include/cppoptlib/solver/lbfgs.h
@@ -3,6 +3,7 @@
 #define INCLUDE_CPPOPTLIB_SOLVER_LBFGS_H_
 
 #include <algorithm>
+#include <utility>
 
 #include "../linesearch/more_thuente.h"
 #include "Eigen/Core"
@@ -35,6 +36,12 @@ class Lbfgs : public Solver<function_t> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit Lbfgs(const State<scalar_t> &stopping_state =
+                     DefaultStoppingSolverState<scalar_t>(),
+                 typename Superclass::callback_t step_callback =
+                     GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
+      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
 
   void InitializeSolver(const function_state_t &initial_state) override {
     dim_ = initial_state.x.rows();

--- a/include/cppoptlib/solver/lbfgsb.h
+++ b/include/cppoptlib/solver/lbfgsb.h
@@ -31,6 +31,12 @@ class Lbfgsb : public Solver<function_t> {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  explicit Lbfgsb(const State<scalar_t> &stopping_state =
+                      DefaultStoppingSolverState<scalar_t>(),
+                  typename Superclass::callback_t step_callback =
+                      GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
+      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
+
   void InitializeSolver(const function_state_t &initial_state) override {
     dim_ = initial_state.x.rows();
 

--- a/include/cppoptlib/solver/newton_descent.h
+++ b/include/cppoptlib/solver/newton_descent.h
@@ -2,6 +2,8 @@
 #ifndef INCLUDE_CPPOPTLIB_SOLVER_NEWTON_DESCENT_H_
 #define INCLUDE_CPPOPTLIB_SOLVER_NEWTON_DESCENT_H_
 
+#include <utility>
+
 #include "../linesearch/armijo.h"
 #include "Eigen/Dense"
 #include "solver.h"  // NOLINT
@@ -22,6 +24,13 @@ class NewtonDescent : public Solver<function_t> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit NewtonDescent(
+      const State<scalar_t> &stopping_state =
+          DefaultStoppingSolverState<scalar_t>(),
+      typename Superclass::callback_t step_callback =
+          GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
+      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
 
   int Order() const override { return 2; }
 

--- a/include/cppoptlib/solver/solver.h
+++ b/include/cppoptlib/solver/solver.h
@@ -99,9 +99,9 @@ struct State {
       if (f_delta_violations >= stop_state.f_delta_violations) {
         status = Status::FDeltaViolation;
         return;
-      } else {
-        f_delta_violations = 0;
       }
+    } else {
+      f_delta_violations = 0;
     }
     if ((stop_state.gradient_norm > 0) &&
         (gradient_norm < stop_state.gradient_norm)) {

--- a/include/cppoptlib/solver/solver.h
+++ b/include/cppoptlib/solver/solver.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <iostream>
 #include <tuple>
+#include <utility>
 
 #include "../function.h"
 
@@ -167,6 +168,8 @@ template <typename function_t>
 class Solver {
  public:
   using state_t = State<typename function_t::scalar_t>;
+  using callback_t = std::function<void(const typename function_t::state_t &,
+                                        const state_t &)>;
 
  private:
   static const int Dim = function_t::Dim;
@@ -176,15 +179,14 @@ class Solver {
   using hessian_t = typename function_t::hessian_t;
 
   using function_state_t = typename function_t::state_t;
-  using callback_t =
-      std::function<void(const function_state_t &, const state_t &)>;
 
  public:
   explicit Solver(const State<scalar_t> &stopping_state =
-                      DefaultStoppingSolverState<scalar_t>())
+                      DefaultStoppingSolverState<scalar_t>(),
+                  callback_t step_callback =
+                      GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
       : stopping_state_(stopping_state),
-        step_callback_(
-            GetDefaultStepCallback<scalar_t, vector_t, hessian_t>()) {}
+        step_callback_(std::move(step_callback)) {}
 
   virtual ~Solver() = default;
 

--- a/src/examples/simple.cc
+++ b/src/examples/simple.cc
@@ -1,6 +1,7 @@
 // Copyright 2020, https://github.com/PatWie/CppNumericalSolvers
 
 #include <iostream>
+#include <limits>
 
 #include "include/cppoptlib/function.h"
 #include "include/cppoptlib/solver/bfgs.h"
@@ -44,8 +45,9 @@ int main(int argc, char const *argv[]) {
   // using Solver = cppoptlib::solver::Lbfgs<Function>;
   using Solver = cppoptlib::solver::Lbfgsb<Function>;
 
+  constexpr auto dim = 2;
   Function f;
-  Function::vector_t x(2);
+  Function::vector_t x(dim);
   x << -1, 2;
 
   auto state = f.Eval(x);
@@ -60,7 +62,11 @@ int main(int argc, char const *argv[]) {
   std::cout << cppoptlib::utils::IsGradientCorrect(f, x) << std::endl;
   std::cout << cppoptlib::utils::IsHessianCorrect(f, x) << std::endl;
 
-  Solver solver;
+  Solver solver{
+      Function::vector_t::Constant(
+          dim, std::numeric_limits<typename Function::scalar_t>::lowest()),
+      Function::vector_t::Constant(
+          dim, std::numeric_limits<typename Function::scalar_t>::max())};
 
   auto [solution, solver_state] = solver.Minimize(f, x);
   std::cout << "argmin " << solution.x.transpose() << std::endl;


### PR DESCRIPTION
* Improved constructors
  * Add ability to specify `stopping_state` and `step_callback` in the constructors of `Solver` and all child classes
  * `Lbfgsb` constructor takes `lower_bound` and `upper_bound` instead of using current hard-coded values. Updated simple and verify code to specify bounds when testing `Lbfgsb`
* Fix build issue with clang from using private member `Dim` of `Function` in `solver.h:175`
* Fix f delta violation count bug where `f_delta_violations` was always reset to 0
* Minor changes:
  * Add additional IDE files to `.gitignore`
  * Modernize linesearch namespace declarations for C++17