### PR TITLE
MoreThuente::cstep fix

### DIFF
--- a/include/cppoptlib/function.h
+++ b/include/cppoptlib/function.h
@@ -83,8 +83,6 @@ class Function {
     utils::ComputeFiniteHessian(*this, x, hessian);
   }
 
-  virtual int Order() const { return 1; }
-
   // For improved performance, this function will return the state directly.
   // Override this method if you can compute the objective value, gradient and
   // Hessian simultaneously.

--- a/include/cppoptlib/linesearch/more_thuente.h
+++ b/include/cppoptlib/linesearch/more_thuente.h
@@ -13,6 +13,7 @@ class MoreThuente {
  public:
   using scalar_t = typename Function::scalar_t;
   using vector_t = typename Function::vector_t;
+  using state_t = typename Function::state_t;
 
   /**
    * @brief use MoreThuente Rule for (strong) Wolfe conditiions
@@ -24,18 +25,16 @@ class MoreThuente {
    * @return step-width
    */
 
-  static scalar_t Search(const vector_t &x, const vector_t &search_direction,
+  static scalar_t Search(const state_t &state, const vector_t &search_direction,
                          const Function &function,
                          const scalar_t alpha_init = 1.0) {
     scalar_t alpha = alpha_init;
-    scalar_t fval = function(x);
-    vector_t g = x.eval();
-    function.Gradient(x, &g);
+    vector_t g = state.gradient;
 
     vector_t s = search_direction.eval();
-    vector_t xx = x.eval();
+    vector_t xx = state.x;
 
-    cvsrch(function, &xx, fval, &g, &alpha, s);
+    cvsrch(function, &xx, state.value, &g, &alpha, s);
 
     return alpha;
   }

--- a/include/cppoptlib/solver/bfgs.h
+++ b/include/cppoptlib/solver/bfgs.h
@@ -50,7 +50,7 @@ class Bfgs : public Solver<function_t> {
     }
 
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current.x, search_direction, function);
+        current, search_direction, function);
 
     const function_state_t next =
         function.Eval(current.x + rate * search_direction, 1);

--- a/include/cppoptlib/solver/conjugated_gradient_descent.h
+++ b/include/cppoptlib/solver/conjugated_gradient_descent.h
@@ -48,7 +48,7 @@ class ConjugatedGradientDescent : public Solver<function_t> {
     previous_ = current;
 
     const scalar_t rate = linesearch::Armijo<function_t, 1>::Search(
-        current.x, search_direction_, function);
+        current, search_direction_, function);
 
     return function.Eval(current.x + rate * search_direction_, 1);
   }

--- a/include/cppoptlib/solver/gradient_descent.h
+++ b/include/cppoptlib/solver/gradient_descent.h
@@ -35,7 +35,7 @@ class GradientDescent : public Solver<function_t> {
                                     const function_state_t &current,
                                     const state_t & /*state*/) override {
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current.x, -current.gradient, function);
+        current, -current.gradient, function);
 
     return function.Eval(current.x - rate * current.gradient, 1);
   }

--- a/include/cppoptlib/solver/lbfgs.h
+++ b/include/cppoptlib/solver/lbfgs.h
@@ -103,7 +103,7 @@ class Lbfgs : public Solver<function_t> {
     }
 
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current.x, -search_direction, function, alpha_init);
+        current, -search_direction, function, alpha_init);
 
     const function_state_t next =
         function.Eval(current.x - rate * search_direction, 1);

--- a/include/cppoptlib/solver/lbfgsb.h
+++ b/include/cppoptlib/solver/lbfgsb.h
@@ -68,7 +68,7 @@ class Lbfgsb : public Solver<function_t> {
     // STEP 4: perform linesearch and STEP 5: compute gradient
     scalar_t alpha_init = 1.0;
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current.x, subspace_min - current.x, function, alpha_init);
+        current, subspace_min - current.x, function, alpha_init);
 
     // update current guess and function information
     const vector_t x_next = current.x - rate * (current.x - subspace_min);

--- a/include/cppoptlib/solver/newton_descent.h
+++ b/include/cppoptlib/solver/newton_descent.h
@@ -11,9 +11,9 @@
 namespace cppoptlib::solver {
 
 template <typename function_t>
-class NewtonDescent : public Solver<function_t> {
+class NewtonDescent : public Solver<function_t, 2> {
  private:
-  using Superclass = Solver<function_t>;
+  using Superclass = Solver<function_t, 2>;
   using state_t = typename Superclass::state_t;
 
   using scalar_t = typename function_t::scalar_t;
@@ -30,9 +30,7 @@ class NewtonDescent : public Solver<function_t> {
           DefaultStoppingSolverState<scalar_t>(),
       typename Superclass::callback_t step_callback =
           GetDefaultStepCallback<scalar_t, vector_t, hessian_t>())
-      : Solver<function_t>{stopping_state, std::move(step_callback)} {}
-
-  int Order() const override { return 2; }
+      : Superclass{stopping_state, std::move(step_callback)} {}
 
   void InitializeSolver(const function_state_t &initial_state) override {
     dim_ = initial_state.x.rows();
@@ -47,9 +45,10 @@ class NewtonDescent : public Solver<function_t> {
 
     const vector_t delta_x = hessian.lu().solve(-current.gradient);
     const scalar_t rate =
-        linesearch::Armijo<function_t, 2>::Search(current, delta_x, function);
+        linesearch::Armijo<function_t, Superclass::Order>::Search(
+            current, delta_x, function);
 
-    return function.Eval(current.x + rate * delta_x, 2);
+    return function.Eval(current.x + rate * delta_x, Superclass::Order);
   }
 
  private:

--- a/include/cppoptlib/solver/newton_descent.h
+++ b/include/cppoptlib/solver/newton_descent.h
@@ -41,17 +41,15 @@ class NewtonDescent : public Solver<function_t> {
   function_state_t OptimizationStep(const function_t &function,
                                     const function_state_t &current,
                                     const state_t & /*state*/) override {
-    function_state_t next = current;
-
     constexpr scalar_t safe_guard = 1e-5;
     const hessian_t hessian =
-        *(next.hessian) + safe_guard * hessian_t::Identity(dim_, dim_);
+        *(current.hessian) + safe_guard * hessian_t::Identity(dim_, dim_);
 
-    const vector_t delta_x = hessian.lu().solve(-next.gradient);
+    const vector_t delta_x = hessian.lu().solve(-current.gradient);
     const scalar_t rate =
-        linesearch::Armijo<function_t, 2>::Search(next.x, delta_x, function);
+        linesearch::Armijo<function_t, 2>::Search(current, delta_x, function);
 
-    return function.Eval(next.x + rate * delta_x, 2);
+    return function.Eval(current.x + rate * delta_x, 2);
   }
 
  private:

--- a/include/cppoptlib/solver/solver.h
+++ b/include/cppoptlib/solver/solver.h
@@ -164,7 +164,7 @@ auto GetEmptyStepCallback() {
 }
 
 // Specifies a solver implementation (of a given order) for a given function
-template <typename function_t>
+template <typename function_t, int Ord = 1>
 class Solver {
  public:
   using state_t = State<typename function_t::scalar_t>;
@@ -172,13 +172,16 @@ class Solver {
                                         const state_t &)>;
 
  private:
-  static const int Dim = function_t::Dim;
+  static constexpr int Dim = function_t::Dim;
   using scalar_t = typename function_t::scalar_t;
   using vector_t = typename function_t::vector_t;
   using matrix_t = typename function_t::matrix_t;
   using hessian_t = typename function_t::hessian_t;
 
   using function_state_t = typename function_t::state_t;
+
+ protected:
+  static constexpr int Order = Ord;
 
  public:
   explicit Solver(const State<scalar_t> &stopping_state =
@@ -190,8 +193,6 @@ class Solver {
 
   virtual ~Solver() = default;
 
-  virtual int Order() const { return 1; }
-
   // Sets a Callback function which is triggered after each update step.
   void SetStepCallback(callback_t step_callback) {
     step_callback_ = step_callback;
@@ -202,7 +203,7 @@ class Solver {
   // Minimizes a given function and returns the function state
   virtual std::tuple<function_state_t, state_t> Minimize(
       const function_t &function, const vector_t &x0) {
-    return this->Minimize(function, function.Eval(x0, this->Order()));
+    return this->Minimize(function, function.Eval(x0, Order));
   }
 
   virtual std::tuple<function_state_t, state_t> Minimize(


### PR DESCRIPTION
I was seeing `MoreThuente::Search` fail and return 0 for a optimization I was working on, but scipy's implementation was working fine for the same problem. After looking at the [`dcstep` implementation used by scipy](https://github.com/scipy/scipy/blob/master/scipy/optimize/minpack2/dcstep.f#L112) and the [original MINPACK implementation](https://ftp.mcs.anl.gov/pub/MINPACK-2/csrch/dcstep.f), I noticed `s` was calculated slightly differently in these implementations. After making the change locally, my optimization succeeded, although scipy usually still produces better results.

Other changes:
* pass `function::State` to linesearch functions to reduce duplicate calculations
* make solver order a template parameter instead of a virtual method