### PR TITLE
Avoid alphaStar = -inf when du contains a zero

### DIFF
--- a/include/cppoptlib/solver/lbfgsb.h
+++ b/include/cppoptlib/solver/lbfgsb.h
@@ -242,13 +242,14 @@ class Lbfgsb : public Solver<function_t> {
             alphastar,
             (upper_bound_(free_variables.at(i)) - x_cp(free_variables.at(i))) /
                 du(i));
-      } else {
+      } else if (du(i) < 0) {
         alphastar = std::min<scalar_t>(
             alphastar,
             (lower_bound_(free_variables.at(i)) - x_cp(free_variables.at(i))) /
                 du(i));
       }
     }
+    assert(alphastar >= 0);
     return alphastar;
   }
 

--- a/include/cppoptlib/solver/lbfgsb.h
+++ b/include/cppoptlib/solver/lbfgsb.h
@@ -242,13 +242,15 @@ class Lbfgsb : public Solver<function_t> {
             alphastar,
             (upper_bound_(free_variables.at(i)) - x_cp(free_variables.at(i))) /
                 du(i));
-      } else {
+      }
+      else if (du(i) < 0) {
         alphastar = std::min<scalar_t>(
             alphastar,
             (lower_bound_(free_variables.at(i)) - x_cp(free_variables.at(i))) /
                 du(i));
       }
     }
+    assert(alphastar >= 0);
     return alphastar;
   }
 


### PR DESCRIPTION
When du(i) == 0 and it's approaching a lower bound, FindAlpha can return -inf. It should only return values in [0,1].
The added check fixes it