### PR TITLE
Reduce function gradient computation

### DIFF
--- a/include/cppoptlib/constrained_function.h
+++ b/include/cppoptlib/constrained_function.h
@@ -14,37 +14,39 @@ namespace cppoptlib::function {
 template <class function_t, std::size_t NumConstraints>
 struct ConstrainedFunction;
 
-template <class cfunction_t>
-struct ConstrainedState : public State<cfunction_t> {
-  static_assert(cfunction_t::NumConstraints > -1,
-                "need a constrained function");
+template <class base_t>
+struct ConstrainedState : public State<base_t> {
+  static_assert(base_t::NumConstraints > 0, "need a constrained function base");
 
-  using state_t = ConstrainedState<cfunction_t>;
+  // Self alias for convenience.
+  using self_t = ConstrainedState<base_t>;
+  // Alias for the unconstrained version of the function base.
+  using unconstrained_base_t = FunctionBase<typename base_t::scalar_t,
+                                            base_t::Dim, base_t::DiffLevel, 0>;
 
-  typename cfunction_t::scalar_t value = 0;
-  typename cfunction_t::vector_t x;
-  typename cfunction_t::vector_t gradient;
+  typename base_t::scalar_t value = 0;
+  typename base_t::vector_t x;
+  typename base_t::vector_t gradient;
 
-  std::array<typename cfunction_t::scalar_t, cfunction_t::NumConstraints>
+  std::array<typename base_t::scalar_t, base_t::NumConstraints>
       lagrange_multipliers;
-  std::array<typename cfunction_t::scalar_t, cfunction_t::NumConstraints>
-      violations;
-  typename cfunction_t::scalar_t penalty = 0;
+  std::array<typename base_t::scalar_t, base_t::NumConstraints> violations;
+  typename base_t::scalar_t penalty = 0;
 
   ConstrainedState() {
-    lagrange_multipliers.fill(typename cfunction_t::scalar_t(0));
-    violations.fill(typename cfunction_t::scalar_t(0));
-    penalty = typename cfunction_t::scalar_t(10);
+    lagrange_multipliers.fill(typename base_t::scalar_t(0));
+    violations.fill(typename base_t::scalar_t(0));
+    penalty = typename base_t::scalar_t(10);
   }
 
-  ConstrainedState(const state_t &rhs) { CopyState(rhs); }  // nolint
+  ConstrainedState(const self_t &rhs) { CopyState(rhs); }  // nolint
 
-  ConstrainedState operator=(const state_t &rhs) {
+  ConstrainedState operator=(const self_t &rhs) {
     CopyState(rhs);
     return *this;
   }
 
-  void CopyState(const state_t &rhs) {
+  void CopyState(const self_t &rhs) {
     value = rhs.value;
     x = rhs.x.eval();
     gradient = rhs.gradient.eval();
@@ -53,9 +55,8 @@ struct ConstrainedState : public State<cfunction_t> {
     violations = rhs.violations;
   }
 
-  State<typename cfunction_t::unconstrained_function_t> AsUnconstrained()
-      const {
-    State<typename cfunction_t::unconstrained_function_t> state;
+  State<unconstrained_base_t> AsUnconstrained() const {
+    State<unconstrained_base_t> state;
     state.value = value;
     state.x = x.eval();
     state.gradient = gradient.eval();
@@ -69,49 +70,119 @@ class UnconstrainedFunctionAdapter
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  UnconstrainedFunctionAdapter(cfunction_t original,
-                               typename cfunction_t::state_t state)
-      : original(original), state(state) {}
+  UnconstrainedFunctionAdapter(cfunction_t constrained_function,
+                               typename cfunction_t::state_t constrained_state)
+      : constrained_function(constrained_function),
+        constrained_state(constrained_state) {}
 
-  typename cfunction_t::unconstrained_function_t::state_t operator()(
-      const typename cfunction_t::types::vector_t &x) const override {
-    const typename cfunction_t::state_t inner =
-        original(x, state.lagrange_multipliers, state.penalty);
-    typename cfunction_t::unconstrained_function_t::state_t outer;
-    outer.value = inner.value;
-    outer.x = inner.x;
-    outer.gradient = inner.gradient;
-    return outer;
+  typename cfunction_t::unconstrained_function_t::base_t::scalar_t operator()(
+      const typename cfunction_t::unconstrained_function_t::base_t::vector_t &x,
+      typename cfunction_t::unconstrained_function_t::base_t::vector_t
+          *gradient = nullptr
+
+  ) const override {
+    return constrained_function(x, constrained_state.lagrange_multipliers,
+                                constrained_state.penalty, gradient);
+  }
+
+  typename cfunction_t::unconstrained_function_t::state_t GetState(
+      const typename cfunction_t::unconstrained_function_t::base_t::vector_t &x)
+      const {
+    const typename cfunction_t::state_t inner = constrained_function.GetState(
+        x, constrained_state.lagrange_multipliers, constrained_state.penalty);
+    typename cfunction_t::unconstrained_function_t::state_t unconstrained_state;
+    unconstrained_state.value = inner.value;
+    unconstrained_state.x = inner.x;
+    if constexpr ((cfunction_t::unconstrained_function_t::Differentiability ==
+                   Differentiability::First) ||
+                  (cfunction_t::unconstrained_function_t::Differentiability ==
+                   Differentiability::Second)) {
+      unconstrained_state.gradient = inner.gradient;
+    }
+    if constexpr (cfunction_t::unconstrained_function_t::Differentiability ==
+                  Differentiability::Second) {
+      unconstrained_state.hessian = inner.hessian;
+    }
+    return unconstrained_state;
   }
 
  private:
-  cfunction_t original;
-  typename cfunction_t::state_t state;
+  cfunction_t constrained_function;
+  typename cfunction_t::state_t constrained_state;
 };
 
 template <class function_t, std::size_t TNumConstraints>
 struct ConstrainedFunction {
   static constexpr int NumConstraints = TNumConstraints;
 
-  using types = typename function_t::types;
-  using scalar_t = typename function_t::types::scalar_t;
-  using vector_t = typename function_t::types::vector_t;
-  using matrix_t = typename function_t::types::matrix_t;
+  using scalar_t = typename function_t::base_t::scalar_t;
+  using vector_t = typename function_t::base_t::vector_t;
+  using matrix_t = typename function_t::base_t::matrix_t;
+  using base_t = FunctionBase<scalar_t, function_t::Dim, function_t::DiffLevel,
+                              TNumConstraints>;
   using unconstrained_function_t = function_t;
 
  public:
-  using state_t =
-      ConstrainedState<ConstrainedFunction<function_t, NumConstraints>>;
-  static constexpr Differentiability diff_level = function_t::diff_level;
+  using state_t = ConstrainedState<base_t>;
+  static constexpr Differentiability DiffLevel = function_t::DiffLevel;
   ConstrainedFunction(
       const function_t *objective,
       const std::array<const function_t *, TNumConstraints> &constraints)
       : objective_(objective), constraints_(constraints) {}
-  state_t operator()(const typename types::vector_t &x,
-                     std::array<scalar_t, TNumConstraints> lagrange_multipliers,
-                     scalar_t penalty) const {
+
+  scalar_t operator()(
+      const typename base_t::vector_t &x,
+      std::array<scalar_t, TNumConstraints> lagrange_multipliers,
+      scalar_t penalty, typename base_t::vector_t *gradient = nullptr) const {
+    scalar_t f;
+    vector_t grad;
+    if (gradient) {
+      f = (*objective_)(x, &grad);
+    } else {
+      f = (*objective_)(x);
+    }
+
+    // Augment the objective with constraint penalties.
+    for (std::size_t i = 0; i < TNumConstraints; ++i) {
+      vector_t scaled_local_grad;
+      scalar_t cost;
+      if (gradient) {
+        cost = constraints_[i]->operator()(x, &scaled_local_grad);
+      } else {
+        cost = constraints_[i]->operator()(x);
+      }
+      const scalar_t violation = cost;
+      const scalar_t lambda = lagrange_multipliers[i];
+
+      // Compute the augmented cost for this constraint.
+      const scalar_t aug_cost =
+          violation + lambda * violation +
+          static_cast<scalar_t>(0.5) * penalty * violation * violation;
+      f += aug_cost;
+
+      if (gradient) {
+        // Augment the gradient only if the constraint is active (i.e. cost >
+        // 0).
+        const scalar_t a = scalar_t(1) + lambda + penalty * violation;
+        scaled_local_grad = a * scaled_local_grad;
+        const typename base_t::vector_t aug_grad =
+            (cost > scalar_t(0)) ? scaled_local_grad
+                                 : base_t::vector_t::Zero(x.size());
+        grad += aug_grad;
+      }
+    }
+
+    if (gradient) {
+      *gradient = grad;
+    }
+    return f;
+  }
+
+  state_t GetState(const typename base_t::vector_t &x,
+                   std::array<scalar_t, TNumConstraints> lagrange_multipliers,
+                   scalar_t penalty) const {
     const typename function_t::state_t objective_state =
-        objective_->operator()(x);
+        objective_->GetState(x);
 
     state_t constrained_state;
     constrained_state.x = objective_state.x;
@@ -121,7 +192,7 @@ struct ConstrainedFunction {
     // Sum augmented penalties for hard constraints.
     for (std::size_t i = 0; i < TNumConstraints; ++i) {
       const typename function_t::state_t constraint_state =
-          constraints_[i]->operator()(x);
+          constraints_[i]->GetState(x);
       const scalar_t cost = constraint_state.value;
       const scalar_t violation = cost;
 
@@ -132,11 +203,11 @@ struct ConstrainedFunction {
       constrained_state.value += aug_cost;
       // Augmented gradient (only active if the constraint is violated).
       const scalar_t a = scalar_t(1) + lambda + penalty * violation;
-      const typename types::vector_t scaled_local_grad =
+      const typename base_t::vector_t scaled_local_grad =
           a * constraint_state.gradient;
-      typename types::vector_t aug_grad = (cost > scalar_t(0))
-                                              ? scaled_local_grad
-                                              : types::vector_t::Zero(x.size());
+      typename base_t::vector_t aug_grad =
+          (cost > scalar_t(0)) ? scaled_local_grad
+                               : base_t::vector_t::Zero(x.size());
       constrained_state.gradient += aug_grad;
       constrained_state.violations[i] = violation;
     }
@@ -148,59 +219,159 @@ struct ConstrainedFunction {
   std::array<const function_t *, TNumConstraints> constraints_;
 };
 
-template <typename function_t>
+template <typename function_t, typename... Constraints>
+auto BuildConstrainedProblem(const function_t *objective,
+                             const Constraints *...constraints) {
+  constexpr std::size_t N = sizeof...(Constraints);
+  return ConstrainedFunction<Function<typename function_t::base_t::scalar_t,
+                                      function_t::Dim, function_t::DiffLevel>,
+                             N>(objective, {constraints...});
+}
+
+template <typename T>
+struct SquaredPenalty {
+  // Returns the penalty: f(x) = x^2
+  inline T operator()(const T &x) const { return x * x; }
+  // Returns the derivative: f'(x) = 2*x
+  inline T derivative(const T &x) const { return 2 * x; }
+};
+
+template <typename function_t,
+          typename PenaltyPolicy =
+              SquaredPenalty<typename function_t::scalar_t>>
 class ZeroConstraint : public function_t {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  // Construct with the original constraint function.
-  explicit ZeroConstraint() {}
-
-  typename function_t::state_t operator()(
-      const typename function_t::vector_t &x) const override {
-    // Evaluate the original constraint: c(x)
-    typename function_t::state_t state = constraint_(x);
-    // Save the original constraint value.
-    typename function_t::scalar_t c_val = state.value;
-    // Transform to squared penalty: f(x) = c(x)^2, with gradient 2*c(x)*c'(x).
-    state.value = c_val * c_val;
-    state.gradient = 2 * c_val * state.gradient;
-    return state;
+  typename function_t::scalar_t operator()(
+      const typename function_t::vector_t &x,
+      typename function_t::vector_t *gradient = nullptr) const override {
+    const PenaltyPolicy policy;
+    if (gradient) {
+      typename function_t::vector_t constraint_grad;
+      // Evaluate the underlying constraint and its gradient.
+      const typename function_t::scalar_t c_val =
+          constraint_(x, &constraint_grad);
+      const typename function_t::scalar_t penalty_value =
+          policy(c_val);  // f(c(x)) = c(x)^2
+      // Chain rule: gradient = policy.derivative(c(x)) * c'(x)
+      *gradient = policy.derivative(c_val) * constraint_grad;
+      return penalty_value;
+    } else {
+      const typename function_t::scalar_t c_val = constraint_(x);
+      return policy(c_val);
+    }
   }
 
  private:
   function_t constraint_;
 };
 
-template <typename function_t>
+template <typename function_t,
+          typename PenaltyPolicy =
+              SquaredPenalty<typename function_t::scalar_t>>
 class NonNegativeConstraint : public function_t {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  // Construct with the original constraint function.
-  explicit NonNegativeConstraint() {}
-
-  typename function_t::state_t operator()(
-      const typename function_t::vector_t &x) const override {
-    // Evaluate the original constraint: c(x)
-    typename function_t::state_t state = constraint_(x);
-    // For inequality constraints, we only penalize when c(x) < 0.
-    if (state.value >= 1e-7) {
-      // Constraint satisfied; no penalty.
-      state.value = 0;
-      state.gradient.setZero();
+  typename function_t::scalar_t operator()(
+      const typename function_t::vector_t &x,
+      typename function_t::vector_t *gradient = nullptr) const override {
+    const PenaltyPolicy policy;
+    // Tolerance below which the constraint is considered violated.
+    const typename function_t::scalar_t tol = 1e-7;
+    if (gradient) {
+      typename function_t::vector_t constraint_grad;
+      const typename function_t::scalar_t c_val =
+          constraint_(x, &constraint_grad);
+      if (c_val >= tol) {
+        gradient->setZero();
+        return 0;
+      } else {
+        const typename function_t::scalar_t violation =
+            -c_val;  // violation is positive
+        const typename function_t::scalar_t penalty_value = policy(violation);
+        // Chain rule: gradient = policy.derivative(violation) * (-c'(x))
+        *gradient = policy.derivative(violation) * (-constraint_grad);
+        return penalty_value;
+      }
     } else {
-      // Constraint violated; penalty = ( - c(x) )^2.
-      typename function_t::scalar_t violation = -state.value;
-      state.value = violation * violation;
-      // Chain rule: gradient = 2*violation * (-c'(x))
-      state.gradient = 2 * violation * (-state.gradient);
+      const typename function_t::scalar_t c_val = constraint_(x);
+      if (c_val >= tol) {
+        return 0;
+      } else {
+        const typename function_t::scalar_t violation = -c_val;
+        return policy(violation);
+      }
     }
-    return state;
   }
 
  private:
   function_t constraint_;
+};
+
+template <typename function_t,
+          typename PenaltyPolicy =
+              SquaredPenalty<typename function_t::scalar_t>>
+class BoxConstraint : public function_t {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /**
+   * @brief Constructs a BoxConstraint with specified lower and upper bounds.
+   *
+   * @param lower The lower bound vector.
+   * @param upper The upper bound vector.
+   */
+  BoxConstraint(const typename function_t::vector_t &lower,
+                const typename function_t::vector_t &upper)
+      : lower_(lower), upper_(upper) {}
+
+  /**
+   * @brief Evaluates the box constraint penalty using a penalty policy.
+   *
+   * For each component of x:
+   *  - If x[i] < lower_[i], the violation is defined as (lower_[i] - x[i]).
+   *  - If x[i] > upper_[i], the violation is defined as (x[i] - upper_[i]).
+   *  - Otherwise, no penalty is added.
+   *
+   * The penalty and its derivative (used for gradient computation) are computed
+   * by the policy.
+   *
+   * @param x The input vector.
+   * @param gradient (Optional) Pointer to store the computed gradient.
+   * @return The total penalty value.
+   */
+  typename function_t::scalar_t operator()(
+      const typename function_t::vector_t &x,
+      typename function_t::vector_t *gradient = nullptr) const override {
+    typename function_t::scalar_t total_penalty = 0;
+    if (gradient) {
+      *gradient = typename function_t::vector_t::Zero(x.size());
+    }
+    const PenaltyPolicy policy;
+    // Evaluate the penalty for each component.
+    for (int i = 0; i < x.size(); ++i) {
+      if (x[i] < lower_[i]) {
+        typename function_t::scalar_t diff = lower_[i] - x[i];
+        total_penalty += policy(diff);
+        if (gradient) {
+          (*gradient)[i] -= policy.derivative(diff);
+        }
+      } else if (x[i] > upper_[i]) {
+        typename function_t::scalar_t diff = x[i] - upper_[i];
+        total_penalty += policy(diff);
+        if (gradient) {
+          (*gradient)[i] += policy.derivative(diff);
+        }
+      }
+    }
+    return total_penalty;
+  }
+
+ private:
+  typename function_t::vector_t lower_;
+  typename function_t::vector_t upper_;
 };
 
 }  // namespace cppoptlib::function

--- a/include/cppoptlib/function.h
+++ b/include/cppoptlib/function.h
@@ -12,137 +12,193 @@ enum class Differentiability {
   Second  // Evaluation, gradient, and Hessian available.
 };
 
-template <typename TFunc>
+/**
+ * @brief Forward declaration for State.
+ *
+ * The State structure is used to encapsulate the result of a function
+ * evaluation, including the function value, the point at which it was
+ * evaluated, and, if available, its derivatives (gradient and Hessian).
+ *
+ * @tparam TBase The base type whose state is being stored.
+ */
+template <typename TBase>
 struct State {
-  using function_t = TFunc;
+  using base_t = TBase;
 };
 
-template <class TScalar, int TDim>
+template <class TScalar, int TDim, Differentiability TDifferentiability,
+          int TNumConstraints = 0>
 class FunctionBase {
  public:
   using scalar_t = TScalar;
   using vector_t = Eigen::Matrix<TScalar, TDim, 1>;
   using matrix_t = Eigen::Matrix<TScalar, TDim, TDim>;
+  static constexpr Differentiability DiffLevel = TDifferentiability;
+  static constexpr int NumConstraints = TNumConstraints;
+  static constexpr int Dim = TDim;
 };
 
 template <class TScalar, int TDim, Differentiability TDifferentiability>
-class Function : public FunctionBase<TScalar, TDim> {
+class Function : public FunctionBase<TScalar, TDim, TDifferentiability> {
  public:
-  using types = FunctionBase<TScalar, TDim>;
+  using base_t = FunctionBase<TScalar, TDim, TDifferentiability>;
   using state_t = State<Function<TScalar, TDim, TDifferentiability>>;
 };
 
 template <class TScalar, int TDim>
-struct State<Function<TScalar, TDim, Differentiability::None>> {
-  using function_t = Function<TScalar, TDim, Differentiability::None>;
-  using state_t = State<function_t>;
+struct State<FunctionBase<TScalar, TDim, Differentiability::None>> {
+  using base_t = FunctionBase<TScalar, TDim, Differentiability::None>;
+  using state_t = State<base_t>;
 
-  static constexpr bool constrained = false;
+  typename base_t::scalar_t value = 0;
+  typename base_t::vector_t x;
 
-  typename function_t::scalar_t value = 0;
-  typename function_t::vector_t x;
+  State() = default;
 
-  State() {}
+  State(const state_t &rhs) : value(rhs.value), x(rhs.x.eval()) {}
 
-  State(const state_t &rhs) { CopyState(rhs); }  // nolint
-
-  State operator=(const state_t &rhs) {
-    CopyState(rhs);
+  state_t &operator=(const state_t &rhs) {
+    if (this != &rhs) {
+      value = rhs.value;
+      x = rhs.x.eval();
+    }
     return *this;
-  }
-
-  void CopyState(const state_t &rhs) {
-    value = rhs.value;
-    x = rhs.x.eval();
   }
 };
 
 template <class TScalar, int TDim>
-struct State<Function<TScalar, TDim, Differentiability::First>> {
-  using function_t = Function<TScalar, TDim, Differentiability::First>;
-  using state_t = State<function_t>;
+struct State<FunctionBase<TScalar, TDim, Differentiability::First>> {
+  using base_t = FunctionBase<TScalar, TDim, Differentiability::First>;
+  using state_t = State<base_t>;
 
-  typename function_t::scalar_t value = 0;
-  typename function_t::vector_t x;
-  typename function_t::vector_t gradient;
+  typename base_t::scalar_t value = 0;
+  typename base_t::vector_t x;
+  typename base_t::vector_t gradient;
 
-  State() {}
+  State() = default;
 
-  State(const state_t &rhs) { CopyState(rhs); }  // nolint
+  State(const state_t &rhs)
+      : value(rhs.value), x(rhs.x.eval()), gradient(rhs.gradient.eval()) {}
 
-  State operator=(const state_t &rhs) {
-    CopyState(rhs);
+  state_t &operator=(const state_t &rhs) {
+    if (this != &rhs) {
+      value = rhs.value;
+      x = rhs.x.eval();
+      gradient = rhs.gradient.eval();
+    }
     return *this;
-  }
-
-  void CopyState(const state_t &rhs) {
-    value = rhs.value;
-    x = rhs.x.eval();
-    gradient = rhs.gradient.eval();
   }
 };
 
 template <class TScalar, int TDim>
-struct State<Function<TScalar, TDim, Differentiability::Second>> {
-  using function_t = Function<TScalar, TDim, Differentiability::Second>;
-  using state_t = State<function_t>;
+struct State<FunctionBase<TScalar, TDim, Differentiability::Second>> {
+  using base_t = FunctionBase<TScalar, TDim, Differentiability::Second>;
+  using state_t = State<base_t>;
 
-  typename function_t::scalar_t value = 0;
-  typename function_t::vector_t x;
-  typename function_t::vector_t gradient;
-  typename function_t::matrix_t hessian;
+  typename base_t::scalar_t value = 0;
+  typename base_t::vector_t x;
+  typename base_t::vector_t gradient;
+  typename base_t::matrix_t hessian;
 
-  State() {}
+  State() = default;
 
-  State(const state_t &rhs) { CopyState(rhs); }  // nolint
+  State(const state_t &rhs)
+      : value(rhs.value),
+        x(rhs.x.eval()),
+        gradient(rhs.gradient.eval()),
+        hessian(rhs.hessian.eval()) {}
 
-  State operator=(const state_t &rhs) {
-    CopyState(rhs);
+  state_t &operator=(const state_t &rhs) {
+    if (this != &rhs) {
+      value = rhs.value;
+      x = rhs.x.eval();
+      gradient = rhs.gradient.eval();
+      hessian = rhs.hessian.eval();
+    }
     return *this;
-  }
-
-  void CopyState(const state_t &rhs) {
-    value = rhs.value;
-    x = rhs.x.eval();
-    gradient = rhs.gradient.eval();
-    hessian = rhs.hessian.eval();
   }
 };
 
+/**
+ * @brief Function interface for functions with no derivative information.
+ *
+ * This class must be derived from by user-defined functions that only provide a
+ * function evaluation (no gradient or Hessian).
+ *
+ * @tparam TScalar The scalar type.
+ * @tparam TDim The dimension of the input vector.
+ */
 template <class TScalar, int TDim>
 class Function<TScalar, TDim, Differentiability::None>
-    : public FunctionBase<TScalar, TDim> {
+    : public FunctionBase<TScalar, TDim, Differentiability::None> {
  public:
-  static constexpr int NumConstraints = 0;
-  static constexpr int Dim = TDim;
-  using types = FunctionBase<TScalar, TDim>;
-  using state_t = State<Function<TScalar, TDim, Differentiability::None>>;
-  static constexpr Differentiability diff_level = Differentiability::None;
-  virtual state_t operator()(const typename types::vector_t &x) const = 0;
+  using base_t = FunctionBase<TScalar, TDim, Differentiability::None>;
+  using state_t = State<base_t>;
+
+  virtual typename base_t::scalar_t operator()(
+      const typename base_t::vector_t &x) const = 0;
+
+  state_t GetState(const typename base_t::vector_t &x) const {
+    state_t state;
+    state.x = x;
+    state.value = this->operator()(x);
+    return state;
+  }
 };
 
+/**
+ * @brief Function interface for functions with gradient information.
+ *
+ * User-defined functions that provide both function evaluation and gradient
+ * computation should derive from this class.
+ *
+ * @tparam TScalar The scalar type.
+ * @tparam TDim The dimension of the input vector.
+ */
 template <class TScalar, int TDim>
 class Function<TScalar, TDim, Differentiability::First>
-    : public FunctionBase<TScalar, TDim> {
+    : public FunctionBase<TScalar, TDim, Differentiability::First> {
  public:
-  static constexpr int NumConstraints = 0;
-  static constexpr int Dim = TDim;
-  using types = FunctionBase<TScalar, TDim>;
-  using state_t = State<Function<TScalar, TDim, Differentiability::First>>;
-  static constexpr Differentiability diff_level = Differentiability::First;
-  virtual state_t operator()(const typename types::vector_t &x) const = 0;
+  using base_t = FunctionBase<TScalar, TDim, Differentiability::First>;
+  using state_t = State<base_t>;
+
+  virtual typename base_t::scalar_t operator()(
+      const typename base_t::vector_t &x,
+      typename base_t::vector_t *gradient = nullptr) const = 0;
+  state_t GetState(const typename base_t::vector_t &x) const {
+    state_t state;
+    state.x = x;
+    state.value = this->operator()(x, &state.gradient);
+    return state;
+  }
 };
 
+/**
+ * @brief Function interface for functions with Hessian information.
+ *
+ * User-defined functions that provide function value, gradient, and Hessian
+ * computations should derive from this class.
+ *
+ * @tparam TScalar The scalar type.
+ * @tparam TDim The dimension of the input vector.
+ */
 template <class TScalar, int TDim>
 class Function<TScalar, TDim, Differentiability::Second>
-    : public FunctionBase<TScalar, TDim> {
+    : public FunctionBase<TScalar, TDim, Differentiability::Second> {
  public:
-  static constexpr int NumConstraints = 0;
-  static constexpr int Dim = TDim;
-  using types = FunctionBase<TScalar, TDim>;
-  using state_t = State<Function<TScalar, TDim, Differentiability::Second>>;
-  static constexpr Differentiability diff_level = Differentiability::Second;
-  virtual state_t operator()(const typename types::vector_t &x) const = 0;
+  using base_t = FunctionBase<TScalar, TDim, Differentiability::Second>;
+  using state_t = State<base_t>;
+
+  virtual typename base_t::scalar_t operator()(
+      const typename base_t::vector_t &x,
+      typename base_t::vector_t *gradient = nullptr,
+      typename base_t::matrix_t *hessian = nullptr) const = 0;
+  state_t GetState(const typename base_t::vector_t &x) const {
+    state_t state;
+    state.x = x;
+    state.value = this->operator()(x, &state.gradient, &state.hessian);
+    return state;
+  }
 };
 
 }  // namespace cppoptlib::function

--- a/include/cppoptlib/linesearch/more_thuente.h
+++ b/include/cppoptlib/linesearch/more_thuente.h
@@ -25,16 +25,17 @@ class MoreThuente {
    * @return step-width
    */
 
-  static scalar_t Search(const state_t &state, const vector_t &search_direction,
+  static scalar_t Search(const vector_t &x, const vector_t &search_direction,
                          const Function &function,
                          const scalar_t alpha_init = 1.0) {
     scalar_t alpha = alpha_init;
-    vector_t g = state.gradient;
+    vector_t g;
+    const scalar_t v = function(x, &g);
 
     vector_t s = search_direction.eval();
-    vector_t xx = state.x;
+    vector_t xx = x;
 
-    cvsrch(function, &xx, state.value, &g, &alpha, s);
+    cvsrch(function, &xx, v, &g, &alpha, s);
 
     return alpha;
   }
@@ -101,9 +102,7 @@ class MoreThuente {
 
       // Test new point.
       *x = wa + *stp * s;
-      const auto state = function(*x);
-      f = state.value;
-      *g = state.gradient;
+      f = function(*x, g);
       nfev++;
       scalar_t dg = g->dot(s);
       scalar_t ftest1 = finit + *stp * dgtest;

--- a/include/cppoptlib/solver/bfgs.h
+++ b/include/cppoptlib/solver/bfgs.h
@@ -11,9 +11,9 @@
 namespace cppoptlib::solver {
 template <typename function_t>
 class Bfgs : public Solver<function_t> {
-  static_assert(function_t::diff_level ==
+  static_assert(function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::First ||
-                    function_t::diff_level ==
+                    function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::Second,
                 "GradientDescent only supports first- or second-order "
                 "differentiable functions");
@@ -51,9 +51,9 @@ class Bfgs : public Solver<function_t> {
     }
 
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current, search_direction, function);
+        current.x, search_direction, function);
 
-    const state_t next(function(current.x + rate * search_direction));
+    const state_t next = function.GetState(current.x + rate * search_direction);
 
     // Update inverse Hessian estimate.
     const vector_t s = rate * search_direction;

--- a/include/cppoptlib/solver/gradient_descent.h
+++ b/include/cppoptlib/solver/gradient_descent.h
@@ -11,9 +11,9 @@
 namespace cppoptlib::solver {
 template <typename function_t>
 class GradientDescent : public Solver<function_t> {
-  static_assert(function_t::diff_level ==
+  static_assert(function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::First ||
-                    function_t::diff_level ==
+                    function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::Second,
                 "GradientDescent only supports first- or second-order "
                 "differentiable functions");
@@ -36,9 +36,9 @@ class GradientDescent : public Solver<function_t> {
   state_t OptimizationStep(const function_t &function, const state_t &current,
                            const progress_t & /*progress*/) override {
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current, -current.gradient, function);
+        current.x, -current.gradient, function);
 
-    return state_t(function(current.x - rate * current.gradient));
+    return function.GetState(current.x - rate * current.gradient);
   }
 };
 

--- a/include/cppoptlib/solver/lbfgs.h
+++ b/include/cppoptlib/solver/lbfgs.h
@@ -22,9 +22,9 @@ void ShiftLeft(T *matrix) {
 
 template <typename function_t, int m = 10>
 class Lbfgs : public Solver<function_t> {
-  static_assert(function_t::diff_level ==
+  static_assert(function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::First ||
-                    function_t::diff_level ==
+                    function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::Second,
                 "L-BFGS only supports first- or second-order "
                 "differentiable functions");
@@ -48,7 +48,7 @@ class Lbfgs : public Solver<function_t> {
   using Superclass::Superclass;
 
   void InitializeSolver(const state_t &initial_state) override {
-    dim_ = initial_state.x.rows();
+    const size_t dim_ = initial_state.x.rows();
     x_diff_memory_ = memory_matrix_t::Zero(dim_, m);
     grad_diff_memory_ = memory_matrix_t::Zero(dim_, m);
     alpha = memory_vector_t::Zero(m);
@@ -122,9 +122,9 @@ class Lbfgs : public Solver<function_t> {
     }
 
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current, -search_direction, function, alpha_init);
+        current.x, -search_direction, function, alpha_init);
 
-    const state_t next(function(current.x - rate * search_direction));
+    const state_t next = function.GetState(current.x - rate * search_direction);
 
     const vector_t x_diff = next.x - current.x;
     const vector_t grad_diff = next.gradient - current.gradient;
@@ -165,13 +165,12 @@ class Lbfgs : public Solver<function_t> {
   }
 
  private:
-  int dim_;
   memory_matrix_t x_diff_memory_;
   memory_matrix_t grad_diff_memory_;
-  size_t memory_idx_;
+  size_t memory_idx_ = 0;
 
   memory_vector_t alpha;
-  scalar_t scaling_factor_;
+  scalar_t scaling_factor_ = 1;
 };
 
 }  // namespace cppoptlib::solver

--- a/include/cppoptlib/solver/lbfgsb.h
+++ b/include/cppoptlib/solver/lbfgsb.h
@@ -16,9 +16,9 @@ namespace cppoptlib::solver {
 
 template <typename function_t, int m = 5>
 class Lbfgsb : public Solver<function_t> {
-  static_assert(function_t::diff_level ==
+  static_assert(function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::First ||
-                    function_t::diff_level ==
+                    function_t::DiffLevel ==
                         cppoptlib::function::Differentiability::Second,
                 "GradientDescent only supports first- or second-order "
                 "differentiable functions");
@@ -81,7 +81,7 @@ class Lbfgsb : public Solver<function_t> {
     // STEP 4: perform linesearch and STEP 5: compute gradient
     scalar_t alpha_init = 1.0;
     const scalar_t rate = linesearch::MoreThuente<function_t, 1>::Search(
-        current, subspace_min - current.x, function, alpha_init);
+        current.x, subspace_min - current.x, function, alpha_init);
 
     // update current guess and function information
     const vector_t x_next = current.x - rate * (current.x - subspace_min);
@@ -89,7 +89,7 @@ class Lbfgsb : public Solver<function_t> {
     const vector_t clipped_x_next =
         x_next.cwiseMin(upper_bound_).cwiseMax(lower_bound_);
 
-    const state_t next(function(clipped_x_next));
+    const state_t next = function.GetState(clipped_x_next);
 
     // prepare for next iteration
     const vector_t new_y = next.gradient - current.gradient;

--- a/include/cppoptlib/solver/nelder_mead.h
+++ b/include/cppoptlib/solver/nelder_mead.h
@@ -52,7 +52,7 @@ class NelderMead : public Solver<function_t> {
     std::vector<scalar_t> f(numVertices);
     std::vector<int> idx(numVertices);
     for (int i = 0; i < numVertices; ++i) {
-      f[i] = function(simplex_.col(i)).value;
+      f[i] = function(simplex_.col(i));
       idx[i] = i;
     }
 
@@ -74,7 +74,7 @@ class NelderMead : public Solver<function_t> {
       simplex_ = makeInitialSimplex(simplex_.col(idx[0]));
       // Recompute function values and re-sort indices.
       for (int i = 0; i < numVertices; ++i) {
-        f[i] = function(simplex_.col(i)).value;
+        f[i] = function(simplex_.col(i));
         idx[i] = i;
       }
       std::sort(idx.begin(), idx.end(),
@@ -90,13 +90,13 @@ class NelderMead : public Solver<function_t> {
 
     // Reflection: compute the reflected point.
     vector_t x_r = (1 + rho_) * x_bar - rho_ * simplex_.col(idx[DIM]);
-    scalar_t f_r = function(x_r).value;
+    scalar_t f_r = function(x_r);
 
     if (f_r < f[idx[0]]) {
       // Expansion: if the reflection is the best so far, try to expand further.
       vector_t x_e =
           (1 + rho_ * xi_) * x_bar - rho_ * xi_ * simplex_.col(idx[DIM]);
-      scalar_t f_e = function(x_e).value;
+      scalar_t f_e = function(x_e);
       if (f_e < f_r) {
         simplex_.col(idx[DIM]) = x_e;
       } else {
@@ -111,7 +111,7 @@ class NelderMead : public Solver<function_t> {
         // Outside contraction.
         vector_t x_c = (1 + rho_ * gamma_) * x_bar -
                        rho_ * gamma_ * simplex_.col(idx[DIM]);
-        scalar_t f_c = function(x_c).value;
+        scalar_t f_c = function(x_c);
         if (f_c <= f_r) {
           simplex_.col(idx[DIM]) = x_c;
         } else {
@@ -120,7 +120,7 @@ class NelderMead : public Solver<function_t> {
       } else {
         // Inside contraction.
         vector_t x_c = (1 - gamma_) * x_bar + gamma_ * simplex_.col(idx[DIM]);
-        scalar_t f_c = function(x_c).value;
+        scalar_t f_c = function(x_c);
         if (f_c < f[idx[DIM]]) {
           simplex_.col(idx[DIM]) = x_c;
         } else {
@@ -130,7 +130,7 @@ class NelderMead : public Solver<function_t> {
     }
 
     // Return the current best vertex.
-    return state_t(function(simplex_.col(idx[0])));
+    return function.GetState(simplex_.col(idx[0]));
   }
 
  private:
@@ -160,10 +160,10 @@ class NelderMead : public Solver<function_t> {
               const function_t &function) {
     const size_t DIM = s.rows();
     // Re-evaluate the best vertex.
-    f[idx[0]] = function(s.col(idx[0])).value;
+    f[idx[0]] = function(s.col(idx[0]));
     for (size_t i = 1; i < DIM + 1; ++i) {
       s.col(idx[i]) = sigma_ * s.col(idx[i]) + (1 - sigma_) * s.col(idx[0]);
-      f[idx[i]] = function(s.col(idx[i])).value;
+      f[idx[i]] = function(s.col(idx[i]));
     }
   }
 };

--- a/include/cppoptlib/solver/newton_descent.h
+++ b/include/cppoptlib/solver/newton_descent.h
@@ -12,7 +12,7 @@ namespace cppoptlib::solver {
 
 template <typename function_t>
 class NewtonDescent : public Solver<function_t> {
-  static_assert(function_t::diff_level ==
+  static_assert(function_t::DiffLevel ==
                     cppoptlib::function::Differentiability::Second,
                 "GradientDescent only supports second-order "
                 "differentiable functions");
@@ -38,14 +38,14 @@ class NewtonDescent : public Solver<function_t> {
   state_t OptimizationStep(const function_t &function, const state_t &current,
                            const progress_t & /*state*/) override {
     constexpr scalar_t safe_guard = 1e-5;
-    const matrix_t hessian =
+    matrix_t hessian =
         current.hessian + safe_guard * matrix_t::Identity(dim_, dim_);
 
     const vector_t delta_x = hessian.lu().solve(-current.gradient);
     const scalar_t rate =
-        linesearch::Armijo<function_t, 2>::Search(current, delta_x, function);
+        linesearch::Armijo<function_t, 2>::Search(current.x, delta_x, function);
 
-    return state_t(function(current.x + rate * delta_x));
+    return function.GetState(current.x + rate * delta_x);
   }
 
  private:

--- a/include/cppoptlib/utils/derivatives.h
+++ b/include/cppoptlib/utils/derivatives.h
@@ -47,10 +47,9 @@ void ComputeFiniteGradient(
     scalar_t ddVal = dd[accuracy] * h;
     (*grad)[d] = 0;
     for (int s = 0; s < innerSteps; ++s) {
-      const auto state = function(x);
       scalar_t tmp = x[d];
       x[d] += coeff2[accuracy][s] * h;
-      (*grad)[d] += coeff[accuracy][s] * state.value;
+      (*grad)[d] += coeff[accuracy][s] * function(x);
       x[d] = tmp;
     }
     (*grad)[d] /= ddVal;
@@ -75,7 +74,7 @@ void ComputeFiniteHessian(
 
   // Make a local copy so we can safely modify it.
   vector_t x = x0;
-  scalar_t f0 = function(x0).value;
+  scalar_t f0 = function(x0);
 
   if (accuracy == 0) {
     // Basic central difference approximation.
@@ -86,10 +85,10 @@ void ComputeFiniteHessian(
       // Diagonal: standard second derivative.
       x = x0;
       x[i] += hi;
-      scalar_t f_plus = function(x).value;
+      scalar_t f_plus = function(x);
       x = x0;
       x[i] -= hi;
-      scalar_t f_minus = function(x).value;
+      scalar_t f_minus = function(x);
       (*hessian)(i, i) = (f_plus - 2 * f0 + f_minus) / (hi * hi);
 
       for (index_t j = i + 1; j < n; j++) {
@@ -99,19 +98,19 @@ void ComputeFiniteHessian(
         x = x0;
         x[i] += hi;
         x[j] += hj;
-        scalar_t f_pp = function(x).value;
+        scalar_t f_pp = function(x);
         x = x0;
         x[i] += hi;
         x[j] -= hj;
-        scalar_t f_pm = function(x).value;
+        scalar_t f_pm = function(x);
         x = x0;
         x[i] -= hi;
         x[j] += hj;
-        scalar_t f_mp = function(x).value;
+        scalar_t f_mp = function(x);
         x = x0;
         x[i] -= hi;
         x[j] -= hj;
-        scalar_t f_mm = function(x).value;
+        scalar_t f_mm = function(x);
         scalar_t d2f = (f_pp - f_pm - f_mp + f_mm) / (4 * hi * hj);
         (*hessian)(i, j) = d2f;
         (*hessian)(j, i) = d2f;
@@ -124,10 +123,10 @@ void ComputeFiniteHessian(
           std::sqrt(machine_eps) * std::max(std::abs(x0[i]), scalar_t(1));
       x = x0;
       x[i] += hi;
-      scalar_t f_plus = function(x).value;
+      scalar_t f_plus = function(x);
       x = x0;
       x[i] -= hi;
-      scalar_t f_minus = function(x).value;
+      scalar_t f_minus = function(x);
       (*hessian)(i, i) = (f_plus - 2 * f0 + f_minus) / (hi * hi);
 
       for (index_t j = i + 1; j < n; j++) {
@@ -143,76 +142,76 @@ void ComputeFiniteHessian(
         x = x0;
         x[i] = tmpi + 1 * h;
         x[j] = tmpj - 2 * h;
-        term1 += function(x).value;
+        term1 += function(x);
         x = x0;
         x[i] = tmpi + 2 * h;
         x[j] = tmpj - 1 * h;
-        term1 += function(x).value;
+        term1 += function(x);
         x = x0;
         x[i] = tmpi - 2 * h;
         x[j] = tmpj + 1 * h;
-        term1 += function(x).value;
+        term1 += function(x);
         x = x0;
         x[i] = tmpi - 1 * h;
         x[j] = tmpj + 2 * h;
-        term1 += function(x).value;
+        term1 += function(x);
 
         // term2: +63 * (f(tmpi-1h, tmpj-2h) + f(tmpi-2h, tmpj-1h) + f(tmpi+1h,
         // tmpj+2h) + f(tmpi+2h, tmpj+1h))
         x = x0;
         x[i] = tmpi - 1 * h;
         x[j] = tmpj - 2 * h;
-        term2 += function(x).value;
+        term2 += function(x);
         x = x0;
         x[i] = tmpi - 2 * h;
         x[j] = tmpj - 1 * h;
-        term2 += function(x).value;
+        term2 += function(x);
         x = x0;
         x[i] = tmpi + 1 * h;
         x[j] = tmpj + 2 * h;
-        term2 += function(x).value;
+        term2 += function(x);
         x = x0;
         x[i] = tmpi + 2 * h;
         x[j] = tmpj + 1 * h;
-        term2 += function(x).value;
+        term2 += function(x);
 
         // term3: +44 * (f(tmpi+2h, tmpj-2h) + f(tmpi-2h, tmpj+2h) - f(tmpi-2h,
         // tmpj-2h) - f(tmpi+2h, tmpj+2h))
         x = x0;
         x[i] = tmpi + 2 * h;
         x[j] = tmpj - 2 * h;
-        term3 += function(x).value;
+        term3 += function(x);
         x = x0;
         x[i] = tmpi - 2 * h;
         x[j] = tmpj + 2 * h;
-        term3 += function(x).value;
+        term3 += function(x);
         x = x0;
         x[i] = tmpi - 2 * h;
         x[j] = tmpj - 2 * h;
-        term3 -= function(x).value;
+        term3 -= function(x);
         x = x0;
         x[i] = tmpi + 2 * h;
         x[j] = tmpj + 2 * h;
-        term3 -= function(x).value;
+        term3 -= function(x);
 
         // term4: +74 * (f(tmpi-1h, tmpj-1h) + f(tmpi+1h, tmpj+1h) - f(tmpi+1h,
         // tmpj-1h) - f(tmpi-1h, tmpj+1h))
         x = x0;
         x[i] = tmpi - 1 * h;
         x[j] = tmpj - 1 * h;
-        term4 += function(x).value;
+        term4 += function(x);
         x = x0;
         x[i] = tmpi + 1 * h;
         x[j] = tmpj + 1 * h;
-        term4 += function(x).value;
+        term4 += function(x);
         x = x0;
         x[i] = tmpi + 1 * h;
         x[j] = tmpj - 1 * h;
-        term4 -= function(x).value;
+        term4 -= function(x);
         x = x0;
         x[i] = tmpi - 1 * h;
         x[j] = tmpj + 1 * h;
-        term4 -= function(x).value;
+        term4 -= function(x);
 
         // Combine the weighted terms.
         scalar_t mixed = (-63 * term1 + 63 * term2 + 44 * term3 + 74 * term4) /
@@ -235,7 +234,8 @@ bool IsGradientCorrect(const function_t &function,
   using index_t = typename vector_t::Index;
 
   const index_t D = x0.rows();
-  vector_t actual_gradient = function(x0).gradient;
+  vector_t actual_gradient;
+  function(x0, &actual_gradient);
   vector_t expected_gradient(D);
 
   ComputeFiniteGradient(function, x0, &expected_gradient, accuracy);
@@ -264,7 +264,8 @@ bool IsHessianCorrect(const function_t &function,
 
   const index_t D = x0.rows();
 
-  matrix_t actual_hessian = function(x0).hessian;
+  matrix_t actual_hessian;
+  function(x0, nullptr, &actual_hessian);
   matrix_t expected_hessian = matrix_t::Zero(D, D);
   ComputeFiniteHessian(function, x0, &expected_hessian, accuracy);
   for (index_t d = 0; d < D; ++d) {

--- a/src/examples/constrained_simple.cc
+++ b/src/examples/constrained_simple.cc
@@ -13,12 +13,12 @@ class SumObjective : public Function2d {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  state_t operator()(const vector_t &x) const override {
-    state_t state;
-    state.x = x;
-    state.value = x.sum();
-    state.gradient = vector_t::Ones(2);
-    return state;
+  scalar_t operator()(const vector_t &x,
+                      vector_t *gradient = nullptr) const override {
+    if (gradient) {
+      *gradient = vector_t::Ones(2);
+    }
+    return x.sum();
   }
 };
 
@@ -27,12 +27,12 @@ class InsideCircleConstraint : public Function2d {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   // Enforces x[0]^2+x[1]^2 <= 2 (inside the circle)
-  state_t operator()(const vector_t &x) const override {
-    state_t state;
-    state.x = x;
-    state.value = 2 - x.squaredNorm();
-    state.gradient = -2 * x;
-    return state;
+  scalar_t operator()(const vector_t &x,
+                      vector_t *gradient = nullptr) const override {
+    if (gradient) {
+      *gradient = -2 * x;
+    }
+    return 2 - x.squaredNorm();
   }
 };
 
@@ -41,18 +41,16 @@ class CircleBoundaryConstraint : public Function2d {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   // Enforces x[0]^2+x[1]^2 == 2 (on the circle boundary)
-  state_t operator()(const vector_t &x) const override {
-    state_t state;
-    state.x = x;
-    state.value = x.squaredNorm() - 2;
-    state.gradient = 2 * x;
-    return state;
+  scalar_t operator()(const vector_t &x,
+                      vector_t *gradient = nullptr) const override {
+    if (gradient) {
+      *gradient = 2 * x;
+    }
+    return x.squaredNorm() - 2;
   }
 };
 
 int main() {
-  using InnerSolver = cppoptlib::solver::Lbfgs<Function2d>;
-
   SumObjective::vector_t x;
   x << 2, 10;
 
@@ -64,17 +62,14 @@ int main() {
   cppoptlib::function::NonNegativeConstraint<InsideCircleConstraint> c1;
   cppoptlib::function::ZeroConstraint<CircleBoundaryConstraint> c2;
 
-  using Function2dC =
-      cppoptlib::function::ConstrainedFunction<Function2d,
-                                               /* num constraints */ 2>;
+  const auto L = cppoptlib::function::BuildConstrainedProblem(&f, &c1, &c2);
 
-  Function2dC L(&f, {&c1, &c2});
-  // cppoptlib::function::ConstrainedState<Function2dC>
-  const auto state = L(x, {0.0, 0.0}, 10.);
+  cppoptlib::solver::Lbfgs<Function2d> inner_solver;
+  cppoptlib::solver::AugmentedLagrangian<decltype(L), decltype(inner_solver)>
+      solver(inner_solver);
 
-  cppoptlib::solver::AugmentedLagrangian<Function2dC, InnerSolver> solver;
-
-  auto [solution, solver_state] = solver.Minimize(L, state);
+  const auto initial_state = L.GetState(x, {0.0, 0.0}, 10.);
+  auto [solution, solver_state] = solver.Minimize(L, initial_state);
   std::cout << "f in argmin " << solution.value << std::endl;
   // Supposed to be [-1, -1].
   std::cout << "argmin " << solution.x.transpose() << std::endl;

--- a/src/examples/simple.cc
+++ b/src/examples/simple.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <limits>
 
+#include "Eigen/Core"
 #include "include/cppoptlib/function.h"
 #include "include/cppoptlib/solver/bfgs.h"
 #include "include/cppoptlib/solver/conjugated_gradient_descent.h"
@@ -15,31 +16,30 @@
 
 using FunctionXd = cppoptlib::function::Function<
     double, Eigen::Dynamic, cppoptlib::function::Differentiability::Second>;
-// Or be more specific.
-using Function2d = cppoptlib::function::Function<
-    double, 2, cppoptlib::function::Differentiability::First>;
 
 class Function : public FunctionXd {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  state_t operator()(const vector_t &x) const override {
-    state_t state;
-    state.x = x;
+  scalar_t operator()(const vector_t &x, vector_t *gradient = nullptr,
+                      matrix_t *hessian = nullptr
 
-    state.value = 5 * x[0] * x[0] + 100 * x[1] * x[1] + 5;
+  ) const override {
+    if (gradient) {
+      gradient->resize(x.size());
+      (*gradient)[0] = 2 * 5 * x[0];
+      (*gradient)[1] = 2 * 100 * x[1];
+    }
 
-    state.gradient = vector_t::Zero(2);
-    state.gradient[0] = 2 * 5 * x[0];
-    state.gradient[1] = 2 * 100 * x[1];
+    if (hessian) {
+      hessian->resize(x.size(), x.size());
+      (*hessian)(0, 0) = 10;
+      (*hessian)(0, 1) = 0;
+      (*hessian)(1, 0) = 0;
+      (*hessian)(1, 1) = 200;
+    }
 
-    state.hessian = matrix_t::Zero(2, 2);
-    state.hessian(0, 0) = 10;
-    state.hessian(0, 1) = 0;
-    state.hessian(1, 0) = 0;
-    state.hessian(1, 1) = 200;
-
-    return state;
+    return 5 * x[0] * x[0] + 100 * x[1] * x[1] + 5;
   }
 };
 
@@ -57,19 +57,21 @@ int main() {
   Function::vector_t x(dim);
   x << -1, 2;
 
-  Function::state_t init_state = f(x);
+  Eigen::VectorXd gradient = Eigen::VectorXd::Zero(2);
+  const double value = f(x, &gradient);
 
-  std::cout << init_state.value << std::endl;
-  std::cout << init_state.gradient << std::endl;
+  std::cout << value << std::endl;
+  std::cout << gradient << std::endl;
 
-  std::cout << cppoptlib::utils::IsGradientCorrect(f, x) << std::endl;
-  std::cout << cppoptlib::utils::IsHessianCorrect(f, x) << std::endl;
+  // std::cout << cppoptlib::utils::IsGradientCorrect(f, x) << std::endl;
+  // std::cout << cppoptlib::utils::IsHessianCorrect(f, x) << std::endl;
 
   // Solver solver;
   Solver solver(cppoptlib::solver::DefaultStoppingSolverProgress<Function>(),
                 cppoptlib::solver::PrintCallback<Function>());
 
-  auto [solution, solver_state] = solver.Minimize(f, init_state);
+  auto initial_state = f.GetState(x);
+  auto [solution, solver_state] = solver.Minimize(f, initial_state);
   std::cout << "argmin " << solution.x.transpose() << std::endl;
   std::cout << "f in argmin " << solution.value << std::endl;
   std::cout << "iterations " << solver_state.num_iterations << std::endl;


### PR DESCRIPTION
Instead of using the full state, in line-search we just want function values. Hence, gradient or Hessian will be only requested if necessary.