### PR TITLE
Remove exception

### DIFF
--- a/include/cppoptlib/function_base.h
+++ b/include/cppoptlib/function_base.h
@@ -106,8 +106,12 @@ struct FunctionCRTP : public FunctionInterface<TScalar, TMode, TDimension> {
       return static_cast<const Derived*>(this)->operator()(x);
     } else if constexpr (TMode == DifferentiabilityMode::First) {
       if (hess) {
-        throw std::runtime_error(
-            "Hessian not available for first order function.");
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+      throw std::runtime_error(
+          "Hessian not available for first order function.");
+#else
+      std::abort();
+#endif
       }
       return static_cast<const Derived*>(this)->operator()(x, grad);
     } else {  // DifferentiabilityMode::Second


### PR DESCRIPTION
We're working in a constrained environment and we are compiling with -f-no-exceptions. Your library is working great for us but we need to remove this exception (it's not in our code path but it gets compiled in). I tried to be as broad with flags as possible, this should cover current/modern implementations as well as legacy gcc clang and msvc. Happy to change the abort as well. Thanks!